### PR TITLE
feat: detect cleanup.files conflicts with template (fixes #124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Added
 ### Fixed
+- Detect when a file is listed in `cleanup.files` but still exists in the template; this would cause repeated add/remove cycles on every run — report an error and abort immediately
 ### Changed
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Exceptions/InvalidTemplateConfigException.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Exceptions/InvalidTemplateConfigException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Exceptions;
+
+public sealed class InvalidTemplateConfigException : Exception
+{
+    public InvalidTemplateConfigException() { }
+
+    public InvalidTemplateConfigException(string? message)
+        : base(message) { }
+
+    public InvalidTemplateConfigException(string? message, Exception? innerException)
+        : base(message: message, innerException: innerException) { }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/BulkTemplateUpdater.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/BulkTemplateUpdater.cs
@@ -659,6 +659,20 @@ public sealed class BulkTemplateUpdater : IBulkTemplateUpdater
         }
     }
 
+    private void ValidateCleanupConflicts(TemplateConfig config, string templateFolder)
+    {
+        foreach ((string fileName, _) in config.Cleanup.Files)
+        {
+            string templateFilePath = Path.GetFullPath(Path.Combine(path1: templateFolder, path2: fileName));
+
+            if (File.Exists(templateFilePath))
+            {
+                this._logger.LogCleanupConflict(fileName: fileName);
+                throw new InvalidTemplateConfigException($"Template configuration conflict: '{fileName}' is listed in cleanup.files but still exists in the template. Remove it from the template or from cleanup.files to prevent repeated add/remove cycles.");
+            }
+        }
+    }
+
     private async ValueTask<int> UpdateResharperSettingsAsync(RepoContext repoContext, TemplateUpdateContext updateContext, DotNetFiles dotNetFiles, CancellationToken cancellationToken)
     {
         if (!updateContext.TemplateConfig.DotNet.JetBrainsDotSettings)
@@ -876,6 +890,7 @@ public sealed class BulkTemplateUpdater : IBulkTemplateUpdater
         string templateFolder = templateRepo.WorkingDirectory;
 
         ValidateConfigPaths(config: templateConfig, templateFolder: templateFolder);
+        this.ValidateCleanupConflicts(config: templateConfig, templateFolder: templateFolder);
 
         DotNetVersionSettings dotNetSettings = await this._globalJson.LoadGlobalJsonAsync(baseFolder: templateFolder, cancellationToken: cancellationToken);
 

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/LoggingExtensions/BulkTemplateUpdaterLoggingExtensions.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/LoggingExtensions/BulkTemplateUpdaterLoggingExtensions.cs
@@ -184,4 +184,7 @@ internal static partial class BulkTemplateUpdaterLoggingExtensions
     [LoggerMessage(EventId = 20, Level = LogLevel.Error, Message = "Configured partial file '{fileName}' is missing from the template. Expected source file: '{sourceFileName}'.")]
     public static partial void LogMissingPartialFileInTemplate(this ILogger<BulkTemplateUpdater> logger, string fileName, string sourceFileName);
 
+    [LoggerMessage(EventId = 21, Level = LogLevel.Error, Message = "Template config conflict: '{fileName}' is listed in cleanup.files but still exists in the template. Remove it from the template or from cleanup.files to prevent repeated add/remove cycles.")]
+    public static partial void LogCleanupConflict(this ILogger<BulkTemplateUpdater> logger, string fileName);
+
 }


### PR DESCRIPTION
## Problem

If a file appears in `cleanup.files` config but still exists at the same path in the template, every run of the template updater would:

1. Copy the file from the template to the repo (copy step)
2. Delete the file from the repo (cleanup step)

This creates an infinite oscillation — the file is added and removed on every single run with no way to break the cycle.

## Fix

Add `ValidateCleanupConflicts` called during context build (alongside the existing `ValidateConfigPaths`). For each entry in `cleanup.files`, check if the file still physically exists in the template folder at the same relative path. If it does, log an error and throw `InvalidTemplateConfigException` to abort all work immediately — before any file copies or deletes are attempted.

New exception class `InvalidTemplateConfigException` (parallel to `BranchAlreadyExistsException`).

New log message EventId=21 for the conflict.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)