### PR TITLE
feat: add unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces
 ### Fixed
 ### Changed
 ### Deprecated
@@ -23,7 +24,6 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - Added Blocked and Refactor labels to LabelsBuilder with appropriate colours and descriptions
 - Unit tests for Credfeto.DotNet.Repo.Tracking with 100% code coverage
 - Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.Release
-- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces
 ### Fixed
 - Fixed spurious GitRepositoryLockedException caused by git background maintenance creating commit-graph lock files in .git/objects/
 - Removed erroneous dollar sign from path glob pattern in LabelsBuilder so project paths are generated correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Releases that have at least been deployed to staging, BUT NOT necessarily releas
 - Added Blocked and Refactor labels to LabelsBuilder with appropriate colours and descriptions
 - Unit tests for Credfeto.DotNet.Repo.Tracking with 100% code coverage
 - Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.Release
+- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces
 ### Fixed
 - Fixed spurious GitRepositoryLockedException caused by git background maintenance creating commit-graph lock files in .git/objects/
 - Removed erroneous dollar sign from path glob pattern in LabelsBuilder so project paths are generated correctly

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests.csproj
@@ -1,0 +1,89 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <Authors>Mark Ridgwell</Authors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <Company>Mark Ridgwell</Company>
+    <Copyright>Mark Ridgwell</Copyright>
+    <DebuggerSupport>true</DebuggerSupport>
+    <Description>Dotnet Repository Update tools</Description>
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <Features>strict;flow-analysis</Features>
+    <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <IsTrimmable>true</IsTrimmable>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
+    <LangVersion>latest</LangVersion>
+    <NeutralLanguage>en-GB</NeutralLanguage>
+    <NoWarn />
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <Nullable>enable</Nullable>
+    <OptimizationPreference>speed</OptimizationPreference>
+    <OutputType>Exe</OutputType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
+    <PackageTags>Nuget;update;tool;packages</PackageTags>
+    <Product>Repository Update Tool</Product>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TieredCompilation>true</TieredCompilation>
+    <TieredPGO>true</TieredPGO>
+    <TreatSpecificWarningsAsErrors />
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <WarningsAsErrors />
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
+    <!-- error NU1902: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known moderate severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
+    <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
+  </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')"/>
+  <ItemGroup>
+    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces\Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.4.1830"/>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.127.1366" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.CodeAnalysis" Version="7.1.21.1364" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.4.1830" PrivateAssets="All" ExcludeAssets="runtime"/>
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.212" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.6.4" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="1.7.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.14.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SmartAnalyzers.CSharpExtensions.Annotations" Version="4.2.11" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.25.0" PrivateAssets="All" ExcludeAssets="runtime"/>
+  </ItemGroup>
+</Project>

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests/IBulkTemplateUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests/IBulkTemplateUpdaterTests.cs
@@ -1,0 +1,31 @@
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests;
+
+public sealed class IBulkTemplateUpdaterTests : TestBase
+{
+    [Fact]
+    public void MustBeAnInterface()
+    {
+        Assert.True(
+            typeof(IBulkTemplateUpdater).IsInterface,
+            userMessage: $"{nameof(IBulkTemplateUpdater)} must be an interface"
+        );
+    }
+
+    [Fact]
+    public void MustBePublic()
+    {
+        Assert.True(
+            typeof(IBulkTemplateUpdater).IsPublic,
+            userMessage: $"{nameof(IBulkTemplateUpdater)} must be public"
+        );
+    }
+
+    [Fact]
+    public void MustHaveBulkUpdateAsyncMethod()
+    {
+        Assert.NotNull(typeof(IBulkTemplateUpdater).GetMethod(nameof(IBulkTemplateUpdater.BulkUpdateAsync)));
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.slnx
+++ b/src/Credfeto.DotNet.Repo.Tools.slnx
@@ -50,6 +50,7 @@
   </Folder>
   <Folder Name="/TemplateUpdate/">
     <Project Path="Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.csproj" />
+    <Project Path="Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests.csproj" />
     <Project Path="Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.csproj" />
     <Project Path="Credfeto.DotNet.Repo.Tools.TemplateUpdate/Credfeto.DotNet.Repo.Tools.TemplateUpdate.csproj" />
   </Folder>


### PR DESCRIPTION
## Summary

- Creates `Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.Tests` project with interface-contract tests for `IBulkTemplateUpdater`
- Tests verify the interface is public, declared as an interface, and has the expected `BulkUpdateAsync` method
- Adds the project to the solution under the TemplateUpdate folder

Closes #150

## Test plan

- [ ] Build passes with no warnings or errors
- [ ] All 6 tests pass (3 per target framework: net9.0, net10.0)
- [ ] Coverage collected for `Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces` assembly