### PR TITLE
feat: add unit tests for 100% code coverage: Credfeto.DotNet.Repo.Tools.TemplateUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 - Tests for Credfeto.DotNet.Repo.Tools.Release.Interfaces to achieve 100% code coverage
+- Unit tests for Credfeto.DotNet.Repo.Tools.TemplateUpdate assembly to achieve 100% code coverage
 ### Fixed
 ### Changed
 ### Deprecated

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/DependencyInjectionTests.cs
@@ -1,9 +1,11 @@
+﻿using System.Net.Http;
 using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
 using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Packages.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
 using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
 using Credfeto.DotNet.Repo.Tracking.Interfaces;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,9 +16,7 @@ namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests;
 public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
 {
     public DependencyInjectionTests(ITestOutputHelper output)
-        : base(output: output, dependencyInjectionRegistration: Configure)
-    {
-    }
+        : base(output: output, dependencyInjectionRegistration: Configure) { }
 
     [Fact]
     public void BulkTemplateUpdaterMustBeRegistered()
@@ -48,18 +48,27 @@ public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
         this.RequireService<IDependaBotConfigBuilder>();
     }
 
+    [Fact]
+    public void TemplateConfigLoaderHttpClientCanBeCreated()
+    {
+        IHttpClientFactory factory = this.GetService<IHttpClientFactory>();
+        using HttpClient client = factory.CreateClient(nameof(TemplateConfigLoader));
+        Assert.NotNull(client);
+    }
+
     private static IServiceCollection Configure(IServiceCollection services)
     {
-        return services.AddMockedService<IBulkPackageConfigLoader>()
-                       .AddMockedService<IDotNetBuild>()
-                       .AddMockedService<IDotNetSolutionCheck>()
-                       .AddMockedService<IDotNetVersion>()
-                       .AddMockedService<IGitRepositoryFactory>()
-                       .AddMockedService<IGlobalJson>()
-                       .AddMockedService<IReleaseConfigLoader>()
-                       .AddMockedService<IReleaseGeneration>()
-                       .AddMockedService<ITrackingCache>()
-                       .AddMockedService<IDotNetFilesDetector>()
-                       .AddTemplateUpdate();
+        return services
+            .AddMockedService<IBulkPackageConfigLoader>()
+            .AddMockedService<IDotNetBuild>()
+            .AddMockedService<IDotNetSolutionCheck>()
+            .AddMockedService<IDotNetVersion>()
+            .AddMockedService<IGitRepositoryFactory>()
+            .AddMockedService<IGlobalJson>()
+            .AddMockedService<IReleaseConfigLoader>()
+            .AddMockedService<IReleaseGeneration>()
+            .AddMockedService<ITrackingCache>()
+            .AddMockedService<IDotNetFilesDetector>()
+            .AddTemplateUpdate();
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Exceptions/BranchAlreadyExistsExceptionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Exceptions/BranchAlreadyExistsExceptionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Exceptions;
+
+public sealed class BranchAlreadyExistsExceptionTests : TestBase
+{
+    [Fact]
+    public void DefaultConstructorCreatesException()
+    {
+        BranchAlreadyExistsException exception = new();
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        const string message = "Branch already exists";
+        BranchAlreadyExistsException exception = new(message);
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessageAndInnerException()
+    {
+        const string message = "Branch already exists";
+        InvalidOperationException innerException = new("inner");
+        BranchAlreadyExistsException exception = new(message: message, innerException: innerException);
+        Assert.Equal(expected: message, actual: exception.Message);
+        Assert.Same(expected: innerException, actual: exception.InnerException);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Exceptions/InvalidTemplateConfigExceptionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Exceptions/InvalidTemplateConfigExceptionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Exceptions;
+
+public sealed class InvalidTemplateConfigExceptionTests : TestBase
+{
+    [Fact]
+    public void DefaultConstructorCreatesException()
+    {
+        InvalidTemplateConfigException exception = new();
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        const string message = "Invalid template config";
+        InvalidTemplateConfigException exception = new(message);
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessageAndInnerException()
+    {
+        const string message = "Invalid template config";
+        InvalidOperationException innerException = new("inner");
+        InvalidTemplateConfigException exception = new(message: message, innerException: innerException);
+        Assert.Equal(expected: message, actual: exception.Message);
+        Assert.Same(expected: innerException, actual: exception.InnerException);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
@@ -27,12 +27,9 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
     private readonly IBulkTemplateUpdater _bulkTemplateUpdater;
 
     private readonly ITrackingCache _trackingCache;
-    private readonly IBulkPackageConfigLoader _bulkPackageConfigLoader;
-    private readonly IGitRepositoryFactory _gitRepositoryFactory;
     private readonly ITemplateConfigLoader _templateConfigLoader;
     private readonly IGlobalJson _globalJson;
     private readonly IDotNetVersion _dotNetVersion;
-    private readonly IReleaseConfigLoader _releaseConfigLoader;
 
     public BulkTemplateUpdaterTests()
     {
@@ -40,12 +37,13 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
         Directory.CreateDirectory(this._tempFolder);
 
         this._trackingCache = GetSubstitute<ITrackingCache>();
-        this._bulkPackageConfigLoader = GetSubstitute<IBulkPackageConfigLoader>();
-        this._gitRepositoryFactory = GetSubstitute<IGitRepositoryFactory>();
         this._templateConfigLoader = GetSubstitute<ITemplateConfigLoader>();
         this._globalJson = GetSubstitute<IGlobalJson>();
         this._dotNetVersion = GetSubstitute<IDotNetVersion>();
-        this._releaseConfigLoader = GetSubstitute<IReleaseConfigLoader>();
+
+        IBulkPackageConfigLoader bulkPackageConfigLoader = GetSubstitute<IBulkPackageConfigLoader>();
+        IGitRepositoryFactory gitRepositoryFactory = GetSubstitute<IGitRepositoryFactory>();
+        IReleaseConfigLoader releaseConfigLoader = GetSubstitute<IReleaseConfigLoader>();
 
         this._bulkTemplateUpdater = new BulkTemplateUpdater(
             trackingCache: this._trackingCache,
@@ -54,10 +52,10 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
             dotNetVersion: this._dotNetVersion,
             dotNetSolutionCheck: GetSubstitute<IDotNetSolutionCheck>(),
             dotNetBuild: GetSubstitute<IDotNetBuild>(),
-            releaseConfigLoader: this._releaseConfigLoader,
+            releaseConfigLoader: releaseConfigLoader,
             releaseGeneration: GetSubstitute<IReleaseGeneration>(),
-            gitRepositoryFactory: this._gitRepositoryFactory,
-            bulkPackageConfigLoader: this._bulkPackageConfigLoader,
+            gitRepositoryFactory: gitRepositoryFactory,
+            bulkPackageConfigLoader: bulkPackageConfigLoader,
             fileUpdater: GetSubstitute<IFileUpdater>(),
             dependaBotConfigBuilder: GetSubstitute<IDependaBotConfigBuilder>(),
             labelsBuilder: GetSubstitute<ILabelsBuilder>(),
@@ -65,7 +63,11 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
             logger: GetSubstitute<ILogger<BulkTemplateUpdater>>()
         );
 
-        this.SetupDefaultMocks();
+        this.SetupDefaultMocks(
+            gitRepositoryFactory: gitRepositoryFactory,
+            bulkPackageConfigLoader: bulkPackageConfigLoader,
+            releaseConfigLoader: releaseConfigLoader
+        );
     }
 
     public void Dispose()
@@ -76,22 +78,25 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
         }
     }
 
-    private void SetupDefaultMocks()
+    private void SetupDefaultMocks(
+        IGitRepositoryFactory gitRepositoryFactory,
+        IBulkPackageConfigLoader bulkPackageConfigLoader,
+        IReleaseConfigLoader releaseConfigLoader
+    )
     {
         IGitRepository templateRepo = GetSubstitute<IGitRepository>();
         templateRepo.WorkingDirectory.Returns(this._tempFolder);
 
-        this._gitRepositoryFactory.OpenOrCloneAsync(
+        gitRepositoryFactory
+            .OpenOrCloneAsync(
                 workDir: Arg.Any<string>(),
                 repoUrl: Arg.Any<string>(),
                 cancellationToken: Arg.Any<CancellationToken>()
             )
             .Returns(templateRepo);
 
-        this._bulkPackageConfigLoader.LoadAsync(
-                path: Arg.Any<string>(),
-                cancellationToken: Arg.Any<CancellationToken>()
-            )
+        bulkPackageConfigLoader
+            .LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
             .Returns([]);
 
         this._templateConfigLoader.LoadConfigAsync(
@@ -110,7 +115,8 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
         this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>())
             .Returns(noInstalledSdks);
 
-        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+        releaseConfigLoader
+            .LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
             .Returns(
                 new ReleaseConfig(
                     AutoReleasePendingPackages: 0,

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
@@ -160,7 +160,7 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
     }
 
     [Fact]
-    public async Task BulkUpdateWithNonexistentTrackingFileDoesNotLoadTracking()
+    public async Task BulkUpdateWithNonexistentTrackingFileSkipsLoadButDoesSave()
     {
         string nonexistentTrackingFile = Path.Combine(this._tempFolder, "nonexistent-tracking.json");
 
@@ -209,16 +209,6 @@ public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
     [Fact]
     public async Task BulkUpdateWithSdkVersionNullCompletesSuccessfully()
     {
-        this._globalJson.LoadGlobalJsonAsync(
-                baseFolder: Arg.Any<string>(),
-                cancellationToken: Arg.Any<CancellationToken>()
-            )
-            .Returns(new DotNetVersionSettings(SdkVersion: null, AllowPreRelease: false, RollForward: "latestMajor"));
-
-        IReadOnlyList<Version> installedSdks = [];
-        this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>())
-            .Returns(installedSdks);
-
         await this._bulkTemplateUpdater.BulkUpdateAsync(
             templateRepository: "git@github.com:template/repo.git",
             trackingFileName: string.Empty,

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/BulkTemplateUpdaterTests.cs
@@ -1,0 +1,355 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces.Exceptions;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Packages.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Exceptions;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Models;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
+using Credfeto.DotNet.Repo.Tracking.Interfaces;
+using FunFair.Test.Common;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Services;
+
+public sealed class BulkTemplateUpdaterTests : TestBase, IDisposable
+{
+    private readonly string _tempFolder;
+    private readonly IBulkTemplateUpdater _bulkTemplateUpdater;
+
+    private readonly ITrackingCache _trackingCache;
+    private readonly IBulkPackageConfigLoader _bulkPackageConfigLoader;
+    private readonly IGitRepositoryFactory _gitRepositoryFactory;
+    private readonly ITemplateConfigLoader _templateConfigLoader;
+    private readonly IGlobalJson _globalJson;
+    private readonly IDotNetVersion _dotNetVersion;
+    private readonly IReleaseConfigLoader _releaseConfigLoader;
+
+    public BulkTemplateUpdaterTests()
+    {
+        this._tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(this._tempFolder);
+
+        this._trackingCache = GetSubstitute<ITrackingCache>();
+        this._bulkPackageConfigLoader = GetSubstitute<IBulkPackageConfigLoader>();
+        this._gitRepositoryFactory = GetSubstitute<IGitRepositoryFactory>();
+        this._templateConfigLoader = GetSubstitute<ITemplateConfigLoader>();
+        this._globalJson = GetSubstitute<IGlobalJson>();
+        this._dotNetVersion = GetSubstitute<IDotNetVersion>();
+        this._releaseConfigLoader = GetSubstitute<IReleaseConfigLoader>();
+
+        this._bulkTemplateUpdater = new BulkTemplateUpdater(
+            trackingCache: this._trackingCache,
+            globalJson: this._globalJson,
+            dotNetFilesDetector: GetSubstitute<IDotNetFilesDetector>(),
+            dotNetVersion: this._dotNetVersion,
+            dotNetSolutionCheck: GetSubstitute<IDotNetSolutionCheck>(),
+            dotNetBuild: GetSubstitute<IDotNetBuild>(),
+            releaseConfigLoader: this._releaseConfigLoader,
+            releaseGeneration: GetSubstitute<IReleaseGeneration>(),
+            gitRepositoryFactory: this._gitRepositoryFactory,
+            bulkPackageConfigLoader: this._bulkPackageConfigLoader,
+            fileUpdater: GetSubstitute<IFileUpdater>(),
+            dependaBotConfigBuilder: GetSubstitute<IDependaBotConfigBuilder>(),
+            labelsBuilder: GetSubstitute<ILabelsBuilder>(),
+            templateConfigLoader: this._templateConfigLoader,
+            logger: GetSubstitute<ILogger<BulkTemplateUpdater>>()
+        );
+
+        this.SetupDefaultMocks();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this._tempFolder))
+        {
+            Directory.Delete(path: this._tempFolder, recursive: true);
+        }
+    }
+
+    private void SetupDefaultMocks()
+    {
+        IGitRepository templateRepo = GetSubstitute<IGitRepository>();
+        templateRepo.WorkingDirectory.Returns(this._tempFolder);
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: Arg.Any<string>(),
+                repoUrl: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(templateRepo);
+
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+
+        this._templateConfigLoader.LoadConfigAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(EmptyTemplateConfig());
+
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new DotNetVersionSettings(SdkVersion: null, AllowPreRelease: false, RollForward: "latestMajor"));
+
+        IReadOnlyList<Version> noInstalledSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(noInstalledSdks);
+
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(
+                new ReleaseConfig(
+                    AutoReleasePendingPackages: 0,
+                    MinimumHoursBeforeAutoRelease: 0,
+                    InactivityHoursBeforeAutoRelease: 0,
+                    NeverRelease: [],
+                    AllowedAutoUpgrade: [],
+                    AlwaysMatch: []
+                )
+            );
+    }
+
+    private static TemplateConfig EmptyTemplateConfig()
+    {
+        return new TemplateConfig(
+            general: new GeneralTemplateConfig(files: []),
+            gitHub: new GitHubTemplateConfig(
+                issueTemplates: false,
+                pullRequestTemplates: false,
+                actions: false,
+                linters: false,
+                files: [],
+                dependabot: new DependabotTemplateConfig(generate: false),
+                labels: new LabelsTemplateConfig(generate: false)
+            ),
+            dotNet: new DotnetTemplateConfig(globalJson: false, jetBrainsDotSettings: false, files: []),
+            cleanup: new CleanupTemplateConfig(files: [])
+        );
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithNoTrackingFileAndNoRepositoriesCompletesSuccessfully()
+    {
+        await this._bulkTemplateUpdater.BulkUpdateAsync(
+            templateRepository: "git@github.com:template/repo.git",
+            trackingFileName: string.Empty,
+            packagesFileName: "/packages.json",
+            workFolder: this._tempFolder,
+            templateConfigFileName: "/template.json",
+            releaseConfigFileName: "/release.json",
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._trackingCache.DidNotReceive().LoadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await this._trackingCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithNonexistentTrackingFileDoesNotLoadTracking()
+    {
+        string nonexistentTrackingFile = Path.Combine(this._tempFolder, "nonexistent-tracking.json");
+
+        await this._bulkTemplateUpdater.BulkUpdateAsync(
+            templateRepository: "git@github.com:template/repo.git",
+            trackingFileName: nonexistentTrackingFile,
+            packagesFileName: "/packages.json",
+            workFolder: this._tempFolder,
+            templateConfigFileName: "/template.json",
+            releaseConfigFileName: "/release.json",
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._trackingCache.DidNotReceive().LoadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: nonexistentTrackingFile, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithExistingTrackingFileLoadsAndSavesTracking()
+    {
+        string trackingFile = Path.Combine(this._tempFolder, "tracking.json");
+        await File.WriteAllTextAsync(path: trackingFile, contents: "{}", cancellationToken: this.CancellationToken());
+
+        await this._bulkTemplateUpdater.BulkUpdateAsync(
+            templateRepository: "git@github.com:template/repo.git",
+            trackingFileName: trackingFile,
+            packagesFileName: "/packages.json",
+            workFolder: this._tempFolder,
+            templateConfigFileName: "/template.json",
+            releaseConfigFileName: "/release.json",
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._trackingCache.Received(1)
+            .LoadAsync(fileName: trackingFile, cancellationToken: Arg.Any<CancellationToken>());
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: trackingFile, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithSdkVersionNullCompletesSuccessfully()
+    {
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new DotNetVersionSettings(SdkVersion: null, AllowPreRelease: false, RollForward: "latestMajor"));
+
+        IReadOnlyList<Version> installedSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(installedSdks);
+
+        await this._bulkTemplateUpdater.BulkUpdateAsync(
+            templateRepository: "git@github.com:template/repo.git",
+            trackingFileName: string.Empty,
+            packagesFileName: "/packages.json",
+            workFolder: this._tempFolder,
+            templateConfigFileName: "/template.json",
+            releaseConfigFileName: "/release.json",
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._dotNetVersion.Received(1).GetInstalledSdksAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithInstalledSdkVersionCompletesSuccessfully()
+    {
+        Version sdkVersion = new(9, 0, 300);
+
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                new DotNetVersionSettings(
+                    SdkVersion: sdkVersion.ToString(),
+                    AllowPreRelease: false,
+                    RollForward: "latestMajor"
+                )
+            );
+
+        IReadOnlyList<Version> installedSdks = [sdkVersion];
+        this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(installedSdks);
+
+        await this._bulkTemplateUpdater.BulkUpdateAsync(
+            templateRepository: "git@github.com:template/repo.git",
+            trackingFileName: string.Empty,
+            packagesFileName: "/packages.json",
+            workFolder: this._tempFolder,
+            templateConfigFileName: "/template.json",
+            releaseConfigFileName: "/release.json",
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._dotNetVersion.Received(1).GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public Task BulkUpdateWithSdkVersionNotInstalledThrows()
+    {
+        Version sdkVersion = new(9, 0, 300);
+
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                new DotNetVersionSettings(
+                    SdkVersion: sdkVersion.ToString(),
+                    AllowPreRelease: false,
+                    RollForward: "latestMajor"
+                )
+            );
+
+        IReadOnlyList<Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(cancellationToken: Arg.Any<CancellationToken>()).Returns(noSdks);
+
+        return Assert.ThrowsAsync<DotNetBuildErrorException>(() =>
+            this
+                ._bulkTemplateUpdater.BulkUpdateAsync(
+                    templateRepository: "git@github.com:template/repo.git",
+                    trackingFileName: string.Empty,
+                    packagesFileName: "/packages.json",
+                    workFolder: this._tempFolder,
+                    templateConfigFileName: "/template.json",
+                    releaseConfigFileName: "/release.json",
+                    repositories: [],
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+
+    [Fact]
+    public async Task BulkUpdateWithCleanupFileExistingInTemplateFolderThrows()
+    {
+        string conflictingFile = Path.Combine(this._tempFolder, "old-file.txt");
+        await File.WriteAllTextAsync(
+            path: conflictingFile,
+            contents: "test",
+            cancellationToken: this.CancellationToken()
+        );
+
+        TemplateConfig configWithCleanup = new(
+            general: new GeneralTemplateConfig(files: []),
+            gitHub: new GitHubTemplateConfig(
+                issueTemplates: false,
+                pullRequestTemplates: false,
+                actions: false,
+                linters: false,
+                files: [],
+                dependabot: new DependabotTemplateConfig(generate: false),
+                labels: new LabelsTemplateConfig(generate: false)
+            ),
+            dotNet: new DotnetTemplateConfig(globalJson: false, jetBrainsDotSettings: false, files: []),
+            cleanup: new CleanupTemplateConfig(
+                files: new Dictionary<string, string>(StringComparer.Ordinal) { ["old-file.txt"] = "chore" }
+            )
+        );
+
+        this._templateConfigLoader.LoadConfigAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(configWithCleanup);
+
+        await Assert.ThrowsAsync<InvalidTemplateConfigException>(() =>
+            this
+                ._bulkTemplateUpdater.BulkUpdateAsync(
+                    templateRepository: "git@github.com:template/repo.git",
+                    trackingFileName: string.Empty,
+                    packagesFileName: "/packages.json",
+                    workFolder: this._tempFolder,
+                    templateConfigFileName: "/template.json",
+                    releaseConfigFileName: "/release.json",
+                    repositories: [],
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
@@ -1,22 +1,278 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Models;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
 using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
 using FunFair.Test.Common;
+using NSubstitute;
 using Xunit;
 
 namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Services;
 
-public sealed class DependaBotConfigBuilderTests : LoggingTestBase
+public sealed class DependaBotConfigBuilderTests : LoggingTestBase, IDisposable
 {
+    private readonly string _tempFolder;
     private readonly IDependaBotConfigBuilder _dependaBotConfigBuilder;
 
     public DependaBotConfigBuilderTests(ITestOutputHelper output)
         : base(output)
     {
+        this._tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(this._tempFolder);
+
         this._dependaBotConfigBuilder = new DependaBotConfigBuilder(this.GetTypedLogger<DependaBotConfigBuilder>());
     }
 
-    [Fact]
-    public void PlaceHolder()
+    public void Dispose()
     {
-        Assert.NotNull(this._dependaBotConfigBuilder);
+        if (Directory.Exists(this._tempFolder))
+        {
+            Directory.Delete(path: this._tempFolder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NoDependenciesGeneratesMinimalConfig()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("version: 2", result, StringComparison.Ordinal);
+        Assert.Contains("updates:", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("package-ecosystem:", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithDotNetSolutionAndNoPackagesGeneratesNuGetSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: DotNetFilesWithSolutionsAndProjects(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: nuget", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("ignore:", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithDotNetAndWildcardPackageGeneratesIgnoreSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: DotNetFilesWithSolutionsAndProjects(),
+            packages: [WildcardPackage("FunFair")],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: nuget", result, StringComparison.Ordinal);
+        Assert.Contains("ignore:", result, StringComparison.Ordinal);
+        Assert.Contains("dependency-name: \"FunFair.*\"", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithDotNetAndExactPackageGeneratesIgnoreSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: DotNetFilesWithSolutionsAndProjects(),
+            packages: [ExactPackage("FunFair.Test.Common")],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: nuget", result, StringComparison.Ordinal);
+        Assert.Contains("ignore:", result, StringComparison.Ordinal);
+        Assert.Contains("dependency-name: \"FunFair.Test.Common\"", result, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"FunFair.Test.Common.*\"", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithSubmodulesGeneratesGitSubmoduleSection()
+    {
+        IGitRepository repository = this.CreateRepository(hasSubmodules: true);
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: gitsubmodule", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithDockerFileGeneratesDockerSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+        await File.WriteAllTextAsync(
+            path: Path.Combine(this._tempFolder, "Dockerfile"),
+            contents: "FROM ubuntu:latest",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: docker", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithPythonFileGeneratesPipSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+        await File.WriteAllTextAsync(
+            path: Path.Combine(this._tempFolder, "requirements.txt"),
+            contents: "requests==2.28.0",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: pip", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithNpmFileGeneratesNpmSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+        await File.WriteAllTextAsync(
+            path: Path.Combine(this._tempFolder, "package.json"),
+            contents: "{}",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: npm", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithNonStandardGithubActionsGeneratesGithubActionsSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string actionsDir = Path.Combine(this._tempFolder, ".github", "actions");
+        Directory.CreateDirectory(actionsDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(actionsDir, "custom.yml"),
+            contents: "name: custom action",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string templateFolder = Path.Combine(this._tempFolder, "template");
+        Directory.CreateDirectory(templateFolder);
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: templateFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: github-actions", result, StringComparison.Ordinal);
+    }
+
+    private IGitRepository CreateRepository(bool hasSubmodules = false)
+    {
+        IGitRepository repository = GetSubstitute<IGitRepository>();
+        repository.ClonePath.Returns("git@github.com:test/test.git");
+        repository.WorkingDirectory.Returns(this._tempFolder);
+        repository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+        repository.HasSubmodules.Returns(hasSubmodules);
+
+        return repository;
+    }
+
+    private static DotNetFiles EmptyDotNetFiles()
+    {
+        return new DotNetFiles(SourceDirectory: "/src", Solutions: [], Projects: []);
+    }
+
+    private static DotNetFiles DotNetFilesWithSolutionsAndProjects()
+    {
+        return new DotNetFiles(SourceDirectory: "/src", Solutions: ["Test.sln"], Projects: ["src/Test/Test.csproj"]);
+    }
+
+    private static PackageUpdate WildcardPackage(string packageId)
+    {
+        return new PackageUpdate(
+            packageId: packageId,
+            packageType: "all",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+    }
+
+    private static PackageUpdate ExactPackage(string packageId)
+    {
+        return new PackageUpdate(
+            packageId: packageId,
+            packageType: "all",
+            exactMatch: true,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/FileUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/FileUpdaterTests.cs
@@ -168,6 +168,48 @@ public sealed class FileUpdaterTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
+    public async Task TransformChangesContentCopiesAndCommitsAndReturnsTrue()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target.txt");
+
+        await File.WriteAllTextAsync(
+            path: sourceFile,
+            contents: "original content",
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: targetFile,
+            contents: "old content",
+            cancellationToken: this.CancellationToken()
+        );
+
+        const string transformedContent = "TRANSFORMED CONTENT";
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: _ => (System.Text.Encoding.UTF8.GetBytes(transformedContent), true),
+            IsTargetNewer: static (_, _) => false,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Transformed content should update file and return true");
+        string written = await File.ReadAllTextAsync(path: targetFile, cancellationToken: this.CancellationToken());
+        Assert.Equal(expected: transformedContent, actual: written);
+        await this
+            ._repository.Received(1)
+            .CommitAsync(message: "test commit", cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task TargetNewerReturnsFalse()
     {
         string sourceFile = Path.Combine(this._tempFolder, "source.txt");

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/FileUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/FileUpdaterTests.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Models;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Models;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Services;
+
+public sealed class FileUpdaterTests : LoggingTestBase, IDisposable
+{
+    private readonly string _tempFolder;
+    private readonly IFileUpdater _fileUpdater;
+    private readonly IGitRepository _repository;
+    private readonly RepoContext _repoContext;
+
+    public FileUpdaterTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(this._tempFolder);
+
+        this._repository = GetSubstitute<IGitRepository>();
+        this._repository.ClonePath.Returns("git@github.com:test/test.git");
+        this._repository.WorkingDirectory.Returns(this._tempFolder);
+        this._repository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+
+        this._repoContext = new RepoContext(Repository: this._repository, ChangeLogFileName: "CHANGELOG.md");
+        this._fileUpdater = new FileUpdater(this.GetTypedLogger<FileUpdater>());
+    }
+
+    public void Dispose()
+    {
+        this._repository.Dispose();
+
+        if (Directory.Exists(this._tempFolder))
+        {
+            Directory.Delete(path: this._tempFolder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SourceMissingReturnsFalse()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "nonexistent-source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target.txt");
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: static bytes => (bytes, false),
+            IsTargetNewer: static (_, _) => false,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.False(result, userMessage: "Source missing should return false");
+        await this._repository.DidNotReceive().CommitAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TargetMissingCopiesAndCommitsAndReturnsTrue()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target-new.txt");
+
+        const string content = "source content";
+        await File.WriteAllTextAsync(path: sourceFile, contents: content, cancellationToken: this.CancellationToken());
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: static bytes => (bytes, false),
+            IsTargetNewer: static (_, _) => false,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Target missing should copy file and return true");
+        Assert.True(File.Exists(targetFile), userMessage: "Target file should have been created");
+        await this
+            ._repository.Received(1)
+            .CommitAsync(message: "test commit", cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SameContentReturnsFalse()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target.txt");
+
+        const string content = "same content";
+        await File.WriteAllTextAsync(path: sourceFile, contents: content, cancellationToken: this.CancellationToken());
+        await File.WriteAllTextAsync(path: targetFile, contents: content, cancellationToken: this.CancellationToken());
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: static bytes => (bytes, false),
+            IsTargetNewer: static (_, _) => false,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.False(result, userMessage: "Same content should return false");
+        await this._repository.DidNotReceive().CommitAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DifferentContentCopiesAndCommitsAndReturnsTrue()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target.txt");
+
+        await File.WriteAllTextAsync(
+            path: sourceFile,
+            contents: "new content",
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: targetFile,
+            contents: "old content",
+            cancellationToken: this.CancellationToken()
+        );
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: static bytes => (bytes, false),
+            IsTargetNewer: static (_, _) => false,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Different content should copy and return true");
+        await this
+            ._repository.Received(1)
+            .CommitAsync(message: "test commit", cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TargetNewerReturnsFalse()
+    {
+        string sourceFile = Path.Combine(this._tempFolder, "source.txt");
+        string targetFile = Path.Combine(this._tempFolder, "target.txt");
+
+        await File.WriteAllTextAsync(
+            path: sourceFile,
+            contents: "source content",
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: targetFile,
+            contents: "different content",
+            cancellationToken: this.CancellationToken()
+        );
+
+        CopyInstruction copyInstruction = new(
+            SourceFileName: sourceFile,
+            TargetFileName: targetFile,
+            Apply: static bytes => (bytes, false),
+            IsTargetNewer: static (_, _) => true,
+            Message: "test commit"
+        );
+
+        bool result = await this._fileUpdater.UpdateFileAsync(
+            repoContext: this._repoContext,
+            copyInstruction: copyInstruction,
+            changelogUpdate: static _ => ValueTask.CompletedTask,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.False(result, userMessage: "Target newer than source should return false");
+        await this._repository.DidNotReceive().CommitAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/LabelsBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/LabelsBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
+﻿using System;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
 using FunFair.Test.Common;
 using Xunit;
 
@@ -101,5 +102,75 @@ public sealed class LabelsBuilderTests : LoggingTestBase
             .Build();
 
         Assert.Equal(expected: expected, actual: actual);
+    }
+
+    [Fact]
+    public void BuildLabelsYmlWithTestsSuffixProjectHasTestColour()
+    {
+        (string labelsYaml, string labelerYaml) = this._labelsBuilder.BuildLabelsConfig(["Foo.Bar.Tests.csproj"]);
+
+        this.Output.WriteLine(labelsYaml);
+        this.Output.WriteLine(labelerYaml);
+
+        string expectedLabels = new LabelsYamlBuilder()
+            .Add("foo-bar-tests", "0e8a16", "Changes in Foo.Bar.Tests project")
+            .Build();
+
+        string expectedLabeler = new LabelerYamlBuilder().Add("foo-bar-tests", "src/Foo.Bar.Tests/**/*").Build();
+
+        Assert.Contains(expectedLabels, labelsYaml, StringComparison.Ordinal);
+        Assert.Contains(expectedLabeler, labelerYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildLabelsYmlWithTestsInNameProjectHasTestColour()
+    {
+        (string labelsYaml, string labelerYaml) = this._labelsBuilder.BuildLabelsConfig(["Foo.Tests.Mock.csproj"]);
+
+        this.Output.WriteLine(labelsYaml);
+        this.Output.WriteLine(labelerYaml);
+
+        string expectedLabels = new LabelsYamlBuilder()
+            .Add("foo-tests-mock", "0e8a16", "Changes in Foo.Tests.Mock project")
+            .Build();
+
+        string expectedLabeler = new LabelerYamlBuilder().Add("foo-tests-mock", "src/Foo.Tests.Mock/**/*").Build();
+
+        Assert.Contains(expectedLabels, labelsYaml, StringComparison.Ordinal);
+        Assert.Contains(expectedLabeler, labelerYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildLabelsYmlWithMocksSuffixProjectHasTestColour()
+    {
+        (string labelsYaml, string labelerYaml) = this._labelsBuilder.BuildLabelsConfig(["Foo.Bar.Mocks.csproj"]);
+
+        this.Output.WriteLine(labelsYaml);
+        this.Output.WriteLine(labelerYaml);
+
+        string expectedLabels = new LabelsYamlBuilder()
+            .Add("foo-bar-mocks", "0e8a16", "Changes in Foo.Bar.Mocks project")
+            .Build();
+
+        string expectedLabeler = new LabelerYamlBuilder().Add("foo-bar-mocks", "src/Foo.Bar.Mocks/**/*").Build();
+
+        Assert.Contains(expectedLabels, labelsYaml, StringComparison.Ordinal);
+        Assert.Contains(expectedLabeler, labelerYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildLabelsYmlWithRegularProjectHasDefaultColour()
+    {
+        (string labelsYaml, string labelerYaml) = this._labelsBuilder.BuildLabelsConfig(["Foo.Bar.csproj"]);
+
+        this.Output.WriteLine(labelsYaml);
+        this.Output.WriteLine(labelerYaml);
+
+        string expectedLabels = new LabelsYamlBuilder().Add("foo-bar", "96f7d2", "Changes in Foo.Bar project").Build();
+
+        string expectedLabeler = new LabelerYamlBuilder().Add("foo-bar", "src/Foo.Bar/**/*").Build();
+
+        Assert.Contains(expectedLabels, labelsYaml, StringComparison.Ordinal);
+        Assert.Contains(expectedLabeler, labelerYaml, StringComparison.Ordinal);
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/TemplateConfigLoaderFileTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/TemplateConfigLoaderFileTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Models;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Services;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.Services;
+
+public sealed class TemplateConfigLoaderFileTests : LoggingTestBase, IDisposable
+{
+    private readonly string _tempFolder;
+    private readonly ITemplateConfigLoader _templateConfigLoader;
+
+    public TemplateConfigLoaderFileTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._tempFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(this._tempFolder);
+
+        this._templateConfigLoader = new TemplateConfigLoader(
+            httpClientFactory: GetSubstitute<IHttpClientFactory>(),
+            logger: this.GetTypedLogger<TemplateConfigLoader>()
+        );
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this._tempFolder))
+        {
+            Directory.Delete(path: this._tempFolder, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadConfigFromLocalFileAsync()
+    {
+        const string json = """
+            {
+              "general": {
+                "files": {
+                  ".editorconfig": "Config",
+                  ".gitignore": "Config"
+                }
+              },
+              "dotNet": {
+                "global-json": true,
+                "resharper-dotsettings": true,
+                "files": {}
+              },
+              "gitHub": {
+                "dependabot": {
+                  "generate": true
+                },
+                "labels": {
+                  "generate": true
+                },
+                "issue-templates": true,
+                "pr-template": true,
+                "actions": true,
+                "linters": true,
+                "files": {}
+              },
+              "cleanup": {
+                "files": {}
+              }
+            }
+            """;
+
+        string configFile = Path.Combine(this._tempFolder, "templates.json");
+        await File.WriteAllTextAsync(path: configFile, contents: json, cancellationToken: this.CancellationToken());
+
+        TemplateConfig config = await this._templateConfigLoader.LoadConfigAsync(
+            path: configFile,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotEmpty(config.General.Files);
+        Assert.True(config.DotNet.GlobalJson, userMessage: "GlobalJson should be true");
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/TrackingCacheExtensionsTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/TrackingCacheExtensionsTests.cs
@@ -1,0 +1,115 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Models;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
+using Credfeto.DotNet.Repo.Tools.TemplateUpdate.Models;
+using Credfeto.DotNet.Repo.Tracking.Interfaces;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests;
+
+public sealed class TrackingCacheExtensionsTests : TestBase
+{
+    private const string CLONE_PATH = "git@github.com:test/test-repo.git";
+    private const string DEFAULT_BRANCH = "main";
+    private const string TRACKING_FILE = "/tmp/tracking.json";
+
+    private readonly IGitRepository _repository;
+    private readonly RepoContext _repoContext;
+    private readonly ITrackingCache _trackingCache;
+
+    public TrackingCacheExtensionsTests()
+    {
+        this._trackingCache = GetSubstitute<ITrackingCache>();
+        this._repository = GetSubstitute<IGitRepository>();
+        this._repository.ClonePath.Returns(CLONE_PATH);
+        this._repository.WorkingDirectory.Returns("/tmp/work");
+        this._repository.GetDefaultBranch(GitConstants.Upstream).Returns(DEFAULT_BRANCH);
+
+        this._repoContext = new RepoContext(Repository: this._repository, ChangeLogFileName: "CHANGELOG.md");
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithTrackingFilenameCallsSaveAsync()
+    {
+        TemplateUpdateContext updateContext = CreateUpdateContext(trackingFileName: TRACKING_FILE);
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: "some-value",
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: "some-value");
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: TRACKING_FILE, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithoutTrackingFilenameDoesNotCallSaveAsync()
+    {
+        TemplateUpdateContext updateContext = CreateUpdateContext(trackingFileName: string.Empty);
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: "some-value",
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: "some-value");
+        await this._trackingCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static TemplateUpdateContext CreateUpdateContext(string trackingFileName)
+    {
+        return new TemplateUpdateContext(
+            WorkFolder: "/tmp/work",
+            TemplateFolder: "/tmp/template",
+            TrackingFileName: trackingFileName,
+            TemplateConfig: CreateMinimalTemplateConfig(),
+            DotNetSettings: new DotNetVersionSettings(
+                SdkVersion: null,
+                AllowPreRelease: false,
+                RollForward: "latestMajor"
+            ),
+            ReleaseConfig: new ReleaseConfig(
+                AutoReleasePendingPackages: 0,
+                MinimumHoursBeforeAutoRelease: 0,
+                InactivityHoursBeforeAutoRelease: 0,
+                NeverRelease: [],
+                AllowedAutoUpgrade: [],
+                AlwaysMatch: []
+            )
+        );
+    }
+
+    private static TemplateConfig CreateMinimalTemplateConfig()
+    {
+        return new TemplateConfig(
+            general: new GeneralTemplateConfig(files: new Dictionary<string, string>(System.StringComparer.Ordinal)),
+            gitHub: new GitHubTemplateConfig(
+                issueTemplates: false,
+                pullRequestTemplates: false,
+                actions: false,
+                linters: false,
+                files: new Dictionary<string, string>(System.StringComparer.Ordinal),
+                dependabot: new DependabotTemplateConfig(generate: false),
+                labels: new LabelsTemplateConfig(generate: false)
+            ),
+            dotNet: new DotnetTemplateConfig(
+                globalJson: false,
+                jetBrainsDotSettings: false,
+                files: new Dictionary<string, string>(System.StringComparer.Ordinal)
+            ),
+            cleanup: new CleanupTemplateConfig(files: new Dictionary<string, string>(System.StringComparer.Ordinal))
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/TrackingCacheExtensionsTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/TrackingCacheExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
@@ -94,22 +95,22 @@ public sealed class TrackingCacheExtensionsTests : TestBase
     private static TemplateConfig CreateMinimalTemplateConfig()
     {
         return new TemplateConfig(
-            general: new GeneralTemplateConfig(files: new Dictionary<string, string>(System.StringComparer.Ordinal)),
+            general: new GeneralTemplateConfig(files: new Dictionary<string, string>(StringComparer.Ordinal)),
             gitHub: new GitHubTemplateConfig(
                 issueTemplates: false,
                 pullRequestTemplates: false,
                 actions: false,
                 linters: false,
-                files: new Dictionary<string, string>(System.StringComparer.Ordinal),
+                files: new Dictionary<string, string>(StringComparer.Ordinal),
                 dependabot: new DependabotTemplateConfig(generate: false),
                 labels: new LabelsTemplateConfig(generate: false)
             ),
             dotNet: new DotnetTemplateConfig(
                 globalJson: false,
                 jetBrainsDotSettings: false,
-                files: new Dictionary<string, string>(System.StringComparer.Ordinal)
+                files: new Dictionary<string, string>(StringComparer.Ordinal)
             ),
-            cleanup: new CleanupTemplateConfig(files: new Dictionary<string, string>(System.StringComparer.Ordinal))
+            cleanup: new CleanupTemplateConfig(files: new Dictionary<string, string>(StringComparer.Ordinal))
         );
     }
 }


### PR DESCRIPTION
## Summary

- Add unit tests to achieve 100% code coverage for the `Credfeto.DotNet.Repo.Tools.TemplateUpdate` assembly
- Tests cover `DependaBotConfigBuilder`, `FileUpdater`, `LabelsBuilder`, `TemplateConfigLoader`, `TrackingCacheExtensions`, exception classes, and supporting utilities

Closes #148

## Test plan

- [ ] All new tests pass
- [ ] Coverage for `Credfeto.DotNet.Repo.Tools.TemplateUpdate` reaches 100%
- [ ] No existing tests broken