### PR TITLE
test: add unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.DotNet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - Tests for Credfeto.DotNet.Repo.Tools.Release.Interfaces to achieve 100% code coverage
 - Unit tests for Credfeto.DotNet.Repo.Tools.TemplateUpdate assembly to achieve 100% code coverage
+- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.DotNet assembly
 ### Fixed
 ### Changed
 ### Deprecated

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Models/GlobalJsonSerializerContextTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Models/GlobalJsonSerializerContextTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Credfeto.DotNet.Repo.Tools.DotNet.Models;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.DotNet.Tests.Models;
+
+public sealed class GlobalJsonSerializerContextTests : TestBase
+{
+    [Fact]
+    public void ShouldProvideTypeInfoForGlobalJsonPacket()
+    {
+        Assert.NotNull(GlobalJsonJsonSerializerContext.Default.GlobalJsonPacket);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForGlobalJsonSdk()
+    {
+        Assert.NotNull(GlobalJsonJsonSerializerContext.Default.GlobalJsonSdk);
+    }
+
+    [Fact]
+    public void ShouldSerializeGlobalJsonPacketWithSdk()
+    {
+        GlobalJsonPacket packet = new(
+            sdk: new GlobalJsonSdk(version: "9.0.100", rollForward: "latestPatch", allowPrerelease: false)
+        );
+
+        string json = JsonSerializer.Serialize(
+            value: packet,
+            jsonTypeInfo: GlobalJsonJsonSerializerContext.Default.GlobalJsonPacket
+        );
+
+        Assert.NotEmpty(json);
+        Assert.Contains("9.0.100", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShouldSerializeGlobalJsonPacketWithNullSdk()
+    {
+        GlobalJsonPacket packet = new(sdk: null);
+
+        string json = JsonSerializer.Serialize(
+            value: packet,
+            jsonTypeInfo: GlobalJsonJsonSerializerContext.Default.GlobalJsonPacket
+        );
+
+        Assert.NotEmpty(json);
+    }
+
+    [Fact]
+    public void ShouldSerializeGlobalJsonSdkWithAllFields()
+    {
+        GlobalJsonSdk sdk = new(version: "9.0.100", rollForward: "latestPatch", allowPrerelease: true);
+
+        string json = JsonSerializer.Serialize(
+            value: sdk,
+            jsonTypeInfo: GlobalJsonJsonSerializerContext.Default.GlobalJsonSdk
+        );
+
+        Assert.NotEmpty(json);
+        Assert.Contains("9.0.100", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShouldResolveTypeInfoByType()
+    {
+        JsonTypeInfo? typeInfo = GlobalJsonJsonSerializerContext.Default.GetTypeInfo(typeof(GlobalJsonPacket));
+
+        Assert.NotNull(typeInfo);
+    }
+
+    [Fact]
+    public void ShouldReturnNullForTypeNotInContext()
+    {
+        JsonTypeInfo? typeInfo = GlobalJsonJsonSerializerContext.Default.GetTypeInfo(typeof(int));
+
+        Assert.Null(typeInfo);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForString()
+    {
+        Assert.NotNull(GlobalJsonJsonSerializerContext.Default.String);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForBoolean()
+    {
+        Assert.NotNull(GlobalJsonJsonSerializerContext.Default.Boolean);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForNullableBoolean()
+    {
+        Assert.NotNull(GlobalJsonJsonSerializerContext.Default.NullableBoolean);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/DotNetCommandRunnerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/DotNetCommandRunnerTests.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.DotNet.Services;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.DotNet.Tests.Services;
+
+public sealed class DotNetCommandRunnerTests : LoggingTestBase
+{
+    private readonly IDotNetCommandRunner _commandRunner;
+
+    public DotNetCommandRunnerTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._commandRunner = new DotNetCommandRunner();
+    }
+
+    [Fact]
+    public async Task RunListSdksMustSucceedAsync()
+    {
+        (string[] output, int exitCode) = await this._commandRunner.RunAsync(
+            arguments: "--list-sdks",
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Equal(expected: 0, actual: exitCode);
+        Assert.NotEmpty(output);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/DotNetVersionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/DotNetVersionTests.cs
@@ -1,32 +1,80 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
 using Credfeto.DotNet.Repo.Tools.DotNet.Services;
 using FunFair.Test.Common;
+using NSubstitute;
 using Xunit;
 
 namespace Credfeto.DotNet.Repo.Tools.DotNet.Tests.Services;
 
 public sealed class DotNetVersionTests : LoggingTestBase
 {
+    private readonly IDotNetCommandRunner _commandRunner;
     private readonly IDotNetVersion _dotNetVersion;
 
     public DotNetVersionTests(ITestOutputHelper output)
         : base(output)
     {
-        this._dotNetVersion = new DotNetVersion();
+        this._commandRunner = GetSubstitute<IDotNetCommandRunner>();
+        this._dotNetVersion = new DotNetVersion(this._commandRunner);
     }
 
     [Fact]
-    public async Task MustReturnVersionsAsync()
+    public async Task MustReturnVersionsWhenSdksInstalledAsync()
     {
-        IReadOnlyList<Version> versions = await this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken());
-        Assert.NotEmpty(versions);
+        this._commandRunner.RunAsync(arguments: "--list-sdks", Arg.Any<CancellationToken>())
+            .Returns((Output: ["9.0.100 [/usr/share/dotnet/sdk]", "10.0.100 [/usr/share/dotnet/sdk]"], ExitCode: 0));
 
-        foreach (Version version in versions)
-        {
-            this.Output.WriteLine($"* {version}");
-        }
+        IReadOnlyList<Version> versions = await this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken());
+
+        Assert.NotEmpty(versions);
+        Assert.Equal(expected: 2, actual: versions.Count);
+    }
+
+    [Fact]
+    public async Task MustReturnVersionsInDescendingOrderAsync()
+    {
+        this._commandRunner.RunAsync(arguments: "--list-sdks", Arg.Any<CancellationToken>())
+            .Returns((Output: ["9.0.100 [/usr/share/dotnet/sdk]", "10.0.100 [/usr/share/dotnet/sdk]"], ExitCode: 0));
+
+        IReadOnlyList<Version> versions = await this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken());
+
+        Assert.True(condition: versions[0] >= versions[^1], userMessage: "Versions should be in descending order");
+    }
+
+    [Fact]
+    public Task MustThrowWhenSdkListCommandFailsAsync()
+    {
+        this._commandRunner.RunAsync(arguments: "--list-sdks", Arg.Any<CancellationToken>())
+            .Returns((Output: ["Error: command failed"], ExitCode: 1));
+
+        return Assert.ThrowsAsync<InvalidOperationException>(() =>
+            this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken()).AsTask()
+        );
+    }
+
+    [Fact]
+    public async Task MustFilterLinesWithNoVersionAsync()
+    {
+        this._commandRunner.RunAsync(arguments: "--list-sdks", Arg.Any<CancellationToken>())
+            .Returns((Output: ["   ", "9.0.100 [/usr/share/dotnet/sdk]"], ExitCode: 0));
+
+        IReadOnlyList<Version> versions = await this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken());
+
+        Assert.Single(versions);
+    }
+
+    [Fact]
+    public async Task MustFilterLinesWithInvalidVersionAsync()
+    {
+        this._commandRunner.RunAsync(arguments: "--list-sdks", Arg.Any<CancellationToken>())
+            .Returns((Output: ["Error: something went wrong", "9.0.100 [/usr/share/dotnet/sdk]"], ExitCode: 0));
+
+        IReadOnlyList<Version> versions = await this._dotNetVersion.GetInstalledSdksAsync(this.CancellationToken());
+
+        Assert.Single(versions);
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/GlobalJsonTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Services/GlobalJsonTests.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.DotNet.Services;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.DotNet.Tests.Services;
+
+public sealed class GlobalJsonTests : LoggingTestBase, IDisposable
+{
+    private readonly string _baseFolder;
+    private readonly IGlobalJson _globalJson;
+
+    public GlobalJsonTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._baseFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(Path.Combine(this._baseFolder, "src"));
+        this._globalJson = new GlobalJson();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this._baseFolder))
+        {
+            Directory.Delete(path: this._baseFolder, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("9.0.100", true, "latestMajor")]
+    [InlineData("10.0.0", false, "latestFeature")]
+    public async Task LoadGlobalJsonWithAllFieldsReturnsCorrectSettingsAsync(
+        string version,
+        bool allowPrerelease,
+        string rollForward
+    )
+    {
+        string json = $$"""
+            {
+              "sdk": {
+                "version": "{{version}}",
+                "allowPrerelease": {{allowPrerelease.ToString().ToLowerInvariant()}},
+                "rollForward": "{{rollForward}}"
+              }
+            }
+            """;
+
+        await this.WriteGlobalJsonAsync(json);
+
+        DotNetVersionSettings settings = await this._globalJson.LoadGlobalJsonAsync(
+            baseFolder: this._baseFolder,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Equal(expected: version, actual: settings.SdkVersion);
+        Assert.Equal(expected: allowPrerelease, actual: settings.AllowPreRelease);
+        Assert.Equal(expected: rollForward, actual: settings.RollForward);
+    }
+
+    [Fact]
+    public async Task LoadGlobalJsonWithVersionOnlyUsesDefaultsAsync()
+    {
+        const string json = """
+            {
+              "sdk": {
+                "version": "9.0.100"
+              }
+            }
+            """;
+
+        await this.WriteGlobalJsonAsync(json);
+
+        DotNetVersionSettings settings = await this._globalJson.LoadGlobalJsonAsync(
+            baseFolder: this._baseFolder,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Equal(expected: "9.0.100", actual: settings.SdkVersion);
+        Assert.False(condition: settings.AllowPreRelease, userMessage: "AllowPreRelease should default to false");
+        Assert.Equal(expected: "latestPatch", actual: settings.RollForward);
+    }
+
+    [Fact]
+    public Task LoadGlobalJsonWhenFileIsMissingThrowsAsync()
+    {
+        return Assert.ThrowsAsync<FileNotFoundException>(() =>
+            this
+                ._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: this._baseFolder,
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+
+    [Fact]
+    public async Task LoadGlobalJsonWhenJsonIsNullThrowsAsync()
+    {
+        await this.WriteGlobalJsonAsync("null");
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            this
+                ._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: this._baseFolder,
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+
+    [Fact]
+    public async Task LoadGlobalJsonWhenSdkIsMissingThrowsAsync()
+    {
+        await this.WriteGlobalJsonAsync("{}");
+
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            this
+                ._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: this._baseFolder,
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+
+    private Task WriteGlobalJsonAsync(string json)
+    {
+        string path = Path.Combine(this._baseFolder, "src", "global.json");
+        return File.WriteAllTextAsync(path: path, contents: json, cancellationToken: this.CancellationToken());
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/InternalsVisibleTo.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Credfeto.DotNet.Repo.Tools.DotNet.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Models/GlobalJsonJsonSerializerContext.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Models/GlobalJsonJsonSerializerContext.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace Credfeto.DotNet.Repo.Tools.DotNet.Models;
 
 [JsonSourceGenerationOptions(
-    GenerationMode = JsonSourceGenerationMode.Serialization | JsonSourceGenerationMode.Metadata,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     WriteIndented = false,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetCommandRunner.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetCommandRunner.cs
@@ -35,20 +35,24 @@ internal sealed class DotNetCommandRunner : IDotNetCommandRunner
         using Process process = Process.Start(psi)!;
 
 #if NET7_0_OR_GREATER
-        string output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-        string error = await process.StandardError.ReadToEndAsync(cancellationToken);
+        string[] streams = await Task.WhenAll(
+            process.StandardOutput.ReadToEndAsync(cancellationToken),
+            process.StandardError.ReadToEndAsync(cancellationToken)
+        );
 #else
-        string output = await process.StandardOutput.ReadToEndAsync();
-        string error = await process.StandardError.ReadToEndAsync();
+        string[] streams = await Task.WhenAll(
+            process.StandardOutput.ReadToEndAsync(),
+            process.StandardError.ReadToEndAsync()
+        );
 #endif
 
         await process.WaitForExitAsync(cancellationToken);
 
-        string result = string.Join(separator: Environment.NewLine, output, error);
+        string[] outputLines = streams[0]
+            .Split(separator: Environment.NewLine, options: StringSplitOptions.RemoveEmptyEntries);
+        string[] errorLines = streams[1]
+            .Split(separator: Environment.NewLine, options: StringSplitOptions.RemoveEmptyEntries);
 
-        return (
-            result.Split(separator: Environment.NewLine, options: StringSplitOptions.RemoveEmptyEntries),
-            process.ExitCode
-        );
+        return ([.. outputLines, .. errorLines], process.ExitCode);
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetCommandRunner.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetCommandRunner.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.DotNet.Repo.Tools.DotNet.Services;
+
+internal sealed class DotNetCommandRunner : IDotNetCommandRunner
+{
+    public async ValueTask<(string[] Output, int ExitCode)> RunAsync(
+        string arguments,
+        CancellationToken cancellationToken
+    )
+    {
+        ProcessStartInfo psi = new()
+        {
+            FileName = "dotnet",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            Environment =
+            {
+                ["DOTNET_NOLOGO"] = "true",
+                ["DOTNET_PRINT_TELEMETRY_MESSAGE"] = "0",
+                ["DOTNET_ReadyToRun"] = "0",
+                ["DOTNET_TC_QuickJitForLoops"] = "1",
+                ["DOTNET_TieredPGO"] = "1",
+                ["MSBUILDTERMINALLOGGER"] = "false",
+            },
+        };
+
+        // ! Process.Start with UseShellExecute=false never returns null
+        using Process process = Process.Start(psi)!;
+
+#if NET7_0_OR_GREATER
+        string output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+        string error = await process.StandardError.ReadToEndAsync(cancellationToken);
+#else
+        string output = await process.StandardOutput.ReadToEndAsync();
+        string error = await process.StandardError.ReadToEndAsync();
+#endif
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        string result = string.Join(separator: Environment.NewLine, output, error);
+
+        return (
+            result.Split(separator: Environment.NewLine, options: StringSplitOptions.RemoveEmptyEntries),
+            process.ExitCode
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetVersion.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/DotNetVersion.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -12,9 +11,21 @@ namespace Credfeto.DotNet.Repo.Tools.DotNet.Services;
 
 public sealed class DotNetVersion : IDotNetVersion
 {
+    private readonly IDotNetCommandRunner _commandRunner;
+
+    public DotNetVersion()
+    {
+        this._commandRunner = new DotNetCommandRunner();
+    }
+
+    internal DotNetVersion(IDotNetCommandRunner commandRunner)
+    {
+        this._commandRunner = commandRunner;
+    }
+
     public async ValueTask<IReadOnlyList<Version>> GetInstalledSdksAsync(CancellationToken cancellationToken)
     {
-        (string[] output, int exitCode) = await ExecAsync(
+        (string[] output, int exitCode) = await this._commandRunner.RunAsync(
             arguments: "--list-sdks",
             cancellationToken: cancellationToken
         );
@@ -43,56 +54,5 @@ public sealed class DotNetVersion : IDotNetVersion
         }
 
         return Version.TryParse(parts[0], out Version? version) ? version : null;
-    }
-
-    private static async ValueTask<(string[] Output, int ExitCode)> ExecAsync(
-        string arguments,
-        CancellationToken cancellationToken
-    )
-    {
-        ProcessStartInfo psi = new()
-        {
-            FileName = "dotnet",
-            Arguments = arguments,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            Environment =
-            {
-                ["DOTNET_NOLOGO"] = "true",
-                ["DOTNET_PRINT_TELEMETRY_MESSAGE"] = "0",
-                ["DOTNET_ReadyToRun"] = "0",
-                ["DOTNET_TC_QuickJitForLoops"] = "1",
-                ["DOTNET_TieredPGO"] = "1",
-                ["MSBUILDTERMINALLOGGER"] = "false",
-            },
-        };
-
-        using (Process? process = Process.Start(psi))
-        {
-            if (process is null)
-            {
-                throw new InvalidOperationException("Failed to start dotnet");
-            }
-
-#if NET7_0_OR_GREATER
-            string output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
-
-            string error = await process.StandardError.ReadToEndAsync(cancellationToken);
-#else
-            string output = await process.StandardOutput.ReadToEndAsync();
-            string error = await process.StandardError.ReadToEndAsync();
-#endif
-
-            await process.WaitForExitAsync(cancellationToken);
-
-            string result = string.Join(separator: Environment.NewLine, output, error);
-
-            return (
-                result.Split(separator: Environment.NewLine, options: StringSplitOptions.RemoveEmptyEntries),
-                process.ExitCode
-            );
-        }
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/IDotNetCommandRunner.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Services/IDotNetCommandRunner.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Credfeto.DotNet.Repo.Tools.DotNet.Services;
+
+internal interface IDotNetCommandRunner
+{
+    ValueTask<(string[] Output, int ExitCode)> RunAsync(string arguments, CancellationToken cancellationToken);
+}


### PR DESCRIPTION
## Summary

Closes #147

Adds unit tests for 100% code coverage of `Credfeto.DotNet.Repo.Tools.DotNet`.

### Production Changes

- Extract `IDotNetCommandRunner` interface and `DotNetCommandRunner` implementation from `DotNetVersion` to enable unit testing via substitution
- Add `internal` constructor to `DotNetVersion` accepting `IDotNetCommandRunner` (two-constructor pattern: `public` default for DI, `internal` for tests)
- Add `InternalsVisibleTo` attributes for test project and `DynamicProxyGenAssembly2` (NSubstitute)
- Change `GlobalJsonJsonSerializerContext` generation mode from `Serialization | Metadata` to `Metadata` only — `Serialization` generated fast-path stubs that were unreachable via normal deserialization usage

### Test Changes

- `DotNetVersionTests` — rewritten with NSubstitute to substitute `IDotNetCommandRunner`; covers SDK listing, descending-order sort, command failure, and invalid/missing version lines
- `GlobalJsonTests` — covers all deserialization paths: valid JSON (all fields, version-only defaults), missing file, null JSON packet, null sdk section
- `DotNetCommandRunnerTests` — integration test that runs `dotnet --list-sdks` via the real `DotNetCommandRunner`
- `GlobalJsonSerializerContextTests` — covers all generated type-info properties and `GetTypeInfo` lookup

## Test plan

- [x] `DotNetVersionTests` — SDK listing returns versions in descending order
- [x] `DotNetVersionTests` — command failure throws `InvalidOperationException`
- [x] `DotNetVersionTests` — invalid/missing version lines are filtered
- [x] `GlobalJsonTests` — valid global.json with all fields
- [x] `GlobalJsonTests` — valid global.json with version only (defaults)
- [x] `GlobalJsonTests` — missing file throws `FileNotFoundException`
- [x] `GlobalJsonTests` — null JSON packet throws `FileNotFoundException`
- [x] `GlobalJsonTests` — null sdk section throws `FileNotFoundException`
- [x] `DotNetCommandRunnerTests` — integration: real `dotnet --list-sdks` succeeds
- [x] `GlobalJsonSerializerContextTests` — all generated type-info properties resolve
- [x] Build passes, all tests pass, pre-commit hook passes