### PR TITLE
feat: add unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Tests for Credfeto.DotNet.Repo.Tools.Release.Interfaces to achieve 100% code coverage
 - Unit tests for Credfeto.DotNet.Repo.Tools.TemplateUpdate assembly to achieve 100% code coverage
 - Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.DotNet assembly
+- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Tools.Packages
 ### Fixed
 ### Changed
 ### Deprecated

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/DependencyInjectionTests.cs
@@ -1,7 +1,9 @@
+using System.Net.Http;
 using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
 using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Packages.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Packages.Services;
 using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
 using Credfeto.DotNet.Repo.Tracking.Interfaces;
 using Credfeto.Package;
@@ -38,6 +40,16 @@ public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
     public void PackageUpdateConfigurationBuilderMustBeRegistered()
     {
         this.RequireService<IPackageUpdateConfigurationBuilder>();
+    }
+
+    [Fact]
+    public void BulkPackageConfigLoaderHttpClientCanBeCreated()
+    {
+        IHttpClientFactory factory = this.GetService<IHttpClientFactory>();
+
+        using HttpClient client = factory.CreateClient(nameof(BulkPackageConfigLoader));
+
+        Assert.NotNull(client);
     }
 
     private static IServiceCollection Configure(IServiceCollection services)

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Exceptions/NoPackagesUpdatedExceptionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Exceptions/NoPackagesUpdatedExceptionTests.cs
@@ -1,0 +1,83 @@
+using System;
+using Credfeto.DotNet.Repo.Tools.Packages.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Exceptions;
+
+public sealed class NoPackagesUpdatedExceptionTests : TestBase
+{
+    [Fact]
+    public void MustBeSealed()
+    {
+        Assert.True(
+            typeof(NoPackagesUpdatedException).IsSealed,
+            userMessage: $"{nameof(NoPackagesUpdatedException)} must be sealed"
+        );
+    }
+
+    [Fact]
+    public void MustDeriveFromException()
+    {
+        Assert.True(
+            typeof(Exception).IsAssignableFrom(typeof(NoPackagesUpdatedException)),
+            userMessage: $"{nameof(NoPackagesUpdatedException)} must derive from {nameof(Exception)}"
+        );
+    }
+
+    [Fact]
+    public void DefaultConstructorCreatesInstance()
+    {
+        NoPackagesUpdatedException exception = new();
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        const string message = "No packages were updated";
+
+        NoPackagesUpdatedException exception = new(message);
+
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageConstructorWithNullMessageAccepted()
+    {
+        NoPackagesUpdatedException exception = new(message: null);
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessage()
+    {
+        const string message = "No packages were updated";
+        InvalidOperationException inner = new("inner");
+
+        NoPackagesUpdatedException exception = new(message: message, innerException: inner);
+
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsInnerException()
+    {
+        const string message = "No packages were updated";
+        InvalidOperationException inner = new("inner");
+
+        NoPackagesUpdatedException exception = new(message: message, innerException: inner);
+
+        Assert.Same(expected: inner, actual: exception.InnerException);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorWithNullsAccepted()
+    {
+        NoPackagesUpdatedException exception = new(message: null, innerException: null);
+
+        Assert.NotNull(exception);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Exceptions/PackageUpdateExceptionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Exceptions/PackageUpdateExceptionTests.cs
@@ -1,0 +1,83 @@
+using System;
+using Credfeto.DotNet.Repo.Tools.Packages.Exceptions;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Exceptions;
+
+public sealed class PackageUpdateExceptionTests : TestBase
+{
+    [Fact]
+    public void MustBeSealed()
+    {
+        Assert.True(
+            typeof(PackageUpdateException).IsSealed,
+            userMessage: $"{nameof(PackageUpdateException)} must be sealed"
+        );
+    }
+
+    [Fact]
+    public void MustDeriveFromException()
+    {
+        Assert.True(
+            typeof(Exception).IsAssignableFrom(typeof(PackageUpdateException)),
+            userMessage: $"{nameof(PackageUpdateException)} must derive from {nameof(Exception)}"
+        );
+    }
+
+    [Fact]
+    public void DefaultConstructorCreatesInstance()
+    {
+        PackageUpdateException exception = new();
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageConstructorSetsMessage()
+    {
+        const string message = "Package update failed";
+
+        PackageUpdateException exception = new(message);
+
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageConstructorWithNullMessageAccepted()
+    {
+        PackageUpdateException exception = new(message: null);
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsMessage()
+    {
+        const string message = "Package update failed";
+        InvalidOperationException inner = new("inner");
+
+        PackageUpdateException exception = new(message: message, innerException: inner);
+
+        Assert.Equal(expected: message, actual: exception.Message);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorSetsInnerException()
+    {
+        const string message = "Package update failed";
+        InvalidOperationException inner = new("inner");
+
+        PackageUpdateException exception = new(message: message, innerException: inner);
+
+        Assert.Same(expected: inner, actual: exception.InnerException);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructorWithNullsAccepted()
+    {
+        PackageUpdateException exception = new(message: null, innerException: null);
+
+        Assert.NotNull(exception);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/PackageConfigSerializationContextTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/PackageConfigSerializationContextTests.cs
@@ -1,0 +1,221 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests;
+
+public sealed class PackageConfigSerializationContextTests : TestBase
+{
+    [Fact]
+    public void ShouldProvideTypeInfoForPackageUpdate()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.PackageUpdate);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForPackageExclude()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.PackageExclude);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForIReadOnlyListPackageUpdate()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.IReadOnlyListPackageUpdate);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForIReadOnlyListPackageExclude()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.IReadOnlyListPackageExclude);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForBoolean()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.Boolean);
+    }
+
+    [Fact]
+    public void ShouldProvideTypeInfoForString()
+    {
+        Assert.NotNull(PackageConfigSerializationContext.Default.String);
+    }
+
+    [Fact]
+    public void ShouldResolveTypeInfoForPackageUpdateByType()
+    {
+        JsonTypeInfo? typeInfo = PackageConfigSerializationContext.Default.GetTypeInfo(typeof(PackageUpdate));
+
+        Assert.NotNull(typeInfo);
+    }
+
+    [Fact]
+    public void ShouldReturnNullForTypeNotInContext()
+    {
+        JsonTypeInfo? typeInfo = PackageConfigSerializationContext.Default.GetTypeInfo(typeof(int));
+
+        Assert.Null(typeInfo);
+    }
+
+    [Fact]
+    public void ShouldSerializePackageUpdateWithNoExcludes()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        string json = JsonSerializer.Serialize(
+            value: package,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.PackageUpdate
+        );
+
+        Assert.NotEmpty(json);
+        Assert.Contains("Test.Package", json, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShouldSerializePackageExclude()
+    {
+        PackageExclude exclude = new(packageId: "Excluded.Package", exactMatch: true);
+
+        string json = JsonSerializer.Serialize(
+            value: exclude,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.PackageExclude
+        );
+
+        Assert.NotEmpty(json);
+        Assert.Contains("Excluded.Package", json, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShouldSerializeIReadOnlyListOfPackageUpdates()
+    {
+        IReadOnlyList<PackageUpdate> packages =
+        [
+            new PackageUpdate(
+                packageId: "Test.Package",
+                packageType: "nuget",
+                exactMatch: false,
+                versionBumpPackage: false,
+                prohibitVersionBumpWhenReferenced: false,
+                exclude: null
+            ),
+        ];
+
+        string json = JsonSerializer.Serialize(
+            value: packages,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.IReadOnlyListPackageUpdate
+        );
+
+        Assert.NotEmpty(json);
+    }
+
+    [Fact]
+    public void ShouldSerializeIReadOnlyListOfPackageExcludes()
+    {
+        IReadOnlyList<PackageExclude> excludes = [new PackageExclude(packageId: "Excluded.Package", exactMatch: false)];
+
+        string json = JsonSerializer.Serialize(
+            value: excludes,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.IReadOnlyListPackageExclude
+        );
+
+        Assert.NotEmpty(json);
+    }
+
+    [Fact]
+    public void ShouldDeserializePackageWithExcludeList()
+    {
+        const string json = """
+            [
+              {
+                "packageId": "Test.Package",
+                "type": "nuget",
+                "exact-match": false,
+                "version-bump-package": false,
+                "prohibit-version-bump-when-referenced": false,
+                "exclude": [
+                  {"packageId": "Excluded.Package", "exact-match": true}
+                ]
+              }
+            ]
+            """;
+
+        IReadOnlyList<PackageUpdate>? result = JsonSerializer.Deserialize(
+            json: json,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.IReadOnlyListPackageUpdate
+        );
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+        IReadOnlyList<PackageExclude>? excludes = result[0].Exclude;
+        Assert.NotNull(excludes);
+        Assert.Single(excludes);
+    }
+
+    [Fact]
+    public void ShouldSerializePackageUpdateWithExcludes()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: [new PackageExclude(packageId: "Excluded.Package", exactMatch: true)]
+        );
+
+        string json = JsonSerializer.Serialize(
+            value: package,
+            jsonTypeInfo: PackageConfigSerializationContext.Default.PackageUpdate
+        );
+
+        Assert.NotEmpty(json);
+        Assert.Contains("Excluded.Package", json, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShouldCreateContextWithNoArgConstructor()
+    {
+        PackageConfigSerializationContext ctx = new();
+
+        Assert.NotNull(ctx);
+    }
+
+    [Fact]
+    public void ShouldDeserializePackageUpdateUsingNewContextInstance()
+    {
+        const string json = """
+            [
+              {
+                "packageId": "Test.Package",
+                "type": "nuget",
+                "exact-match": false,
+                "version-bump-package": false,
+                "prohibit-version-bump-when-referenced": false,
+                "exclude": [
+                  {"packageId": "Excluded.Package", "exact-match": false}
+                ]
+              }
+            ]
+            """;
+
+        PackageConfigSerializationContext ctx = new();
+        IReadOnlyList<PackageUpdate>? result = JsonSerializer.Deserialize(
+            json: json,
+            jsonTypeInfo: ctx.IReadOnlyListPackageUpdate
+        );
+
+        Assert.NotNull(result);
+        Assert.Single(result);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/PackageUpdateContextTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/PackageUpdateContextTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests;
+
+public sealed class PackageUpdateContextTests : TestBase
+{
+    private const string WORK_FOLDER = "/tmp/work";
+    private const string CACHE_FILE = "/tmp/cache.json";
+    private const string TRACKING_FILE = "/tmp/tracking.json";
+
+    private static readonly DotNetVersionSettings DefaultDotNetSettings = new(
+        SdkVersion: "9.0.100",
+        AllowPreRelease: false,
+        RollForward: "latestMajor"
+    );
+
+    private static readonly ReleaseConfig DefaultReleaseConfig = new(
+        AutoReleasePendingPackages: 1,
+        MinimumHoursBeforeAutoRelease: 5,
+        InactivityHoursBeforeAutoRelease: 9,
+        NeverRelease: [],
+        AllowedAutoUpgrade: [],
+        AlwaysMatch: []
+    );
+
+    [Fact]
+    public void WorkFolderIsSet()
+    {
+        PackageUpdateContext context = CreateContext(workFolder: WORK_FOLDER);
+
+        Assert.Equal(expected: WORK_FOLDER, actual: context.WorkFolder);
+    }
+
+    [Fact]
+    public void CacheFileNameIsSet()
+    {
+        PackageUpdateContext context = CreateContext(cacheFileName: CACHE_FILE);
+
+        Assert.Equal(expected: CACHE_FILE, actual: context.CacheFileName);
+    }
+
+    [Fact]
+    public void CacheFileNameCanBeNull()
+    {
+        PackageUpdateContext context = CreateContext(cacheFileName: null);
+
+        Assert.Null(context.CacheFileName);
+    }
+
+    [Fact]
+    public void TrackingFileNameIsSet()
+    {
+        PackageUpdateContext context = CreateContext(trackingFileName: TRACKING_FILE);
+
+        Assert.Equal(expected: TRACKING_FILE, actual: context.TrackingFileName);
+    }
+
+    [Fact]
+    public void AdditionalSourcesAreSet()
+    {
+        IReadOnlyList<string> sources = ["https://example.com/nuget/v3/index.json"];
+        PackageUpdateContext context = CreateContext(additionalSources: sources);
+
+        Assert.Equal(expected: sources, actual: context.AdditionalSources);
+    }
+
+    [Fact]
+    public void DotNetSettingsAreSet()
+    {
+        PackageUpdateContext context = CreateContext(dotNetSettings: DefaultDotNetSettings);
+
+        Assert.Equal(expected: DefaultDotNetSettings, actual: context.DotNetSettings);
+    }
+
+    [Fact]
+    public void ReleaseConfigIsSet()
+    {
+        PackageUpdateContext context = CreateContext(releaseConfig: DefaultReleaseConfig);
+
+        Assert.Equal(expected: DefaultReleaseConfig, actual: context.ReleaseConfig);
+    }
+
+    private static PackageUpdateContext CreateContext(
+        string workFolder = WORK_FOLDER,
+        string? cacheFileName = CACHE_FILE,
+        string trackingFileName = TRACKING_FILE,
+        IReadOnlyList<string>? additionalSources = null,
+        DotNetVersionSettings? dotNetSettings = null,
+        ReleaseConfig? releaseConfig = null
+    )
+    {
+        return new PackageUpdateContext(
+            WorkFolder: workFolder,
+            CacheFileName: cacheFileName,
+            TrackingFileName: trackingFileName,
+            AdditionalSources: additionalSources ?? [],
+            DotNetSettings: dotNetSettings ?? DefaultDotNetSettings,
+            ReleaseConfig: releaseConfig ?? DefaultReleaseConfig
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageConfigLoaderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageConfigLoaderTests.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
+using Credfeto.DotNet.Repo.Tools.Packages.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Packages.Services;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Services;
+
+public sealed class BulkPackageConfigLoaderTests : LoggingFolderCleanupTestBase
+{
+    private const string ValidPackageJson =
+        """[{"packageId":"Test.Package","type":"nuget","exact-match":false,"version-bump-package":false,"prohibit-version-bump-when-referenced":false}]""";
+
+    private const string EmptyPackageJson = "[]";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IBulkPackageConfigLoader _loader;
+
+    public BulkPackageConfigLoaderTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._httpClientFactory = GetSubstitute<IHttpClientFactory>();
+
+        this._loader = new BulkPackageConfigLoader(
+            httpClientFactory: this._httpClientFactory,
+            logger: this.GetTypedLogger<BulkPackageConfigLoader>()
+        );
+    }
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+
+        public MockHttpMessageHandler(string responseContent)
+        {
+            this._responseContent = responseContent;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken
+        )
+        {
+            return Task.FromResult(
+                new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        content: this._responseContent,
+                        encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                        mediaType: "application/json"
+                    ),
+                }
+            );
+        }
+    }
+
+    [Fact]
+    public async Task LoadFromFileWithValidContentReturnsPackagesAsync()
+    {
+        string fileName = Path.Combine(path1: this.TempFolder, path2: "packages.json");
+        await File.WriteAllTextAsync(
+            path: fileName,
+            contents: ValidPackageJson,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken: this.CancellationToken()
+        );
+
+        IReadOnlyList<PackageUpdate> result = await this._loader.LoadAsync(
+            path: fileName,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public async Task LoadFromFileWithValidContentReturnsCorrectPackageIdAsync()
+    {
+        string fileName = Path.Combine(path1: this.TempFolder, path2: "packages.json");
+        await File.WriteAllTextAsync(
+            path: fileName,
+            contents: ValidPackageJson,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken: this.CancellationToken()
+        );
+
+        IReadOnlyList<PackageUpdate> result = await this._loader.LoadAsync(
+            path: fileName,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Equal(expected: "Test.Package", actual: result[0].PackageId);
+    }
+
+    [Fact]
+    public async Task LoadFromFileWithEmptyArrayThrowsInvalidOperationExceptionAsync()
+    {
+        string fileName = Path.Combine(path1: this.TempFolder, path2: "packages-empty.json");
+        await File.WriteAllTextAsync(
+            path: fileName,
+            contents: EmptyPackageJson,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken: this.CancellationToken()
+        );
+
+        await Assert.ThrowsAsync<InvalidOperationException>(testCode: async () =>
+            await this._loader.LoadAsync(path: fileName, cancellationToken: this.CancellationToken())
+        );
+    }
+
+    [Fact]
+    public async Task LoadFromFileWithMultiplePackagesReturnsAllAsync()
+    {
+        const string multiplePackageJson = """
+            [
+              {"packageId":"Package.A","type":"nuget","exact-match":false,"version-bump-package":false,"prohibit-version-bump-when-referenced":false},
+              {"packageId":"Package.B","type":"nuget","exact-match":true,"version-bump-package":false,"prohibit-version-bump-when-referenced":false}
+            ]
+            """;
+        string fileName = Path.Combine(path1: this.TempFolder, path2: "packages-multi.json");
+        await File.WriteAllTextAsync(
+            path: fileName,
+            contents: multiplePackageJson,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken: this.CancellationToken()
+        );
+
+        IReadOnlyList<PackageUpdate> result = await this._loader.LoadAsync(
+            path: fileName,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.Equal(expected: 2, actual: result.Count);
+    }
+
+    [Fact]
+    public async Task LoadFromHttpWithValidContentReturnsPackagesAsync()
+    {
+        using MockHttpMessageHandler handler = new(ValidPackageJson);
+        using HttpClient httpClient = new(handler);
+        this._httpClientFactory.CreateClient(name: nameof(BulkPackageConfigLoader)).Returns(httpClient);
+
+        IReadOnlyList<PackageUpdate> result = await this._loader.LoadAsync(
+            path: "http://example.com/packages.json",
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.NotEmpty(result);
+    }
+
+    [Fact]
+    public async Task LoadFromHttpWithEmptyArrayThrowsInvalidOperationExceptionAsync()
+    {
+        using MockHttpMessageHandler handler = new(EmptyPackageJson);
+        using HttpClient httpClient = new(handler);
+        this._httpClientFactory.CreateClient(name: nameof(BulkPackageConfigLoader)).Returns(httpClient);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await this._loader.LoadAsync(
+                path: "http://example.com/packages.json",
+                cancellationToken: this.CancellationToken()
+            )
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageUpdaterTests.cs
@@ -973,4 +973,158 @@ public sealed class BulkPackageUpdaterTests : LoggingFolderCleanupTestBase
             this._projectLoader.Received(1).Reset();
         }
     }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoHavingDotNetFilesAndPackageUpdateReturnsTrueDoesNotCallReleaseGenerationAsync()
+    {
+        string repoDir = Path.Combine(this.TempFolder, "repo");
+        Directory.CreateDirectory(repoDir);
+        LibGit2Sharp.Repository.Init(repoDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(repoDir, "CHANGELOG.md"),
+            contents: "# Changelog",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string solutionFile = Path.Combine(repoDir, "Test.sln");
+        string srcDir = Path.Combine(repoDir, "src");
+        Directory.CreateDirectory(srcDir);
+        string projectFile = Path.Combine(srcDir, "Test.csproj");
+        await File.WriteAllTextAsync(
+            path: solutionFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: projectFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageUpdate packageUpdate = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        using (LibGit2Sharp.Repository realRepo = new(repoDir))
+        {
+            this._repoRepository.Active.Returns(realRepo);
+            this._repoRepository.WorkingDirectory.Returns(repoDir);
+            this._repoRepository.ClonePath.Returns(REPO_URL);
+            this._repoRepository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+            this._repoRepository.HeadRev.Returns("abc123deadbeef");
+
+            this._gitRepositoryFactory.OpenOrCloneAsync(
+                    workDir: WORK_FOLDER,
+                    repoUrl: REPO_URL,
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(this._repoRepository);
+
+            this._dotNetFilesDetector.FindAsync(baseFolder: repoDir, cancellationToken: Arg.Any<CancellationToken>())
+                .Returns(new DotNetFiles(SourceDirectory: repoDir, Solutions: [solutionFile], Projects: [projectFile]));
+
+            this._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: Arg.Any<string>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(DefaultDotNetSettings);
+
+            this._dotNetBuild.LoadBuildSettingsAsync(
+                    projects: Arg.Any<IReadOnlyList<string>>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(new BuildSettings(PublishableProjects: [], PackableProjects: [], Framework: null));
+
+            this._singlePackageUpdater.UpdateAsync(
+                    updateContext: Arg.Any<PackageUpdateContext>(),
+                    repoContext: Arg.Any<Credfeto.DotNet.Repo.Tools.Models.RepoContext>(),
+                    solutions: Arg.Any<IReadOnlyList<string>>(),
+                    sourceDirectory: Arg.Any<string>(),
+                    buildSettings: Arg.Any<BuildSettings>(),
+                    dotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                    package: Arg.Any<PackageUpdate>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(true);
+
+            PackageUpdateContext context = CreateUpdateContext();
+
+            await this._updater.UpdateRepositoriesAsync(
+                updateContext: context,
+                repositories: [REPO_URL],
+                packages: [packageUpdate],
+                cancellationToken: this.CancellationToken()
+            );
+
+            await this
+                ._releaseGeneration.DidNotReceive()
+                .TryCreateNextPatchAsync(
+                    repoContext: Arg.Any<Credfeto.DotNet.Repo.Tools.Models.RepoContext>(),
+                    dotNetFiles: Arg.Any<DotNetFiles>(),
+                    buildSettings: Arg.Any<BuildSettings>(),
+                    dotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                    packages: Arg.Any<IReadOnlyList<PackageUpdate>>(),
+                    releaseConfig: Arg.Any<ReleaseConfig>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                );
+        }
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithNonExistentTrackingFileDoesNotLoadTrackingAsync()
+    {
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        string nonExistentTracking = Path.Combine(this.TempFolder, "nonexistent-tracking.json");
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: null,
+            trackingFileName: nonExistentTracking,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._trackingCache.DidNotReceive().LoadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/BulkPackageUpdaterTests.cs
@@ -1,0 +1,976 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.ChangeLog.Exceptions;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces.Exceptions;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces.Exceptions;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
+using Credfeto.DotNet.Repo.Tools.Packages.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Packages.Services;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces.Exceptions;
+using Credfeto.DotNet.Repo.Tracking.Interfaces;
+using Credfeto.Package;
+using FunFair.Test.Common;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Services;
+
+public sealed class BulkPackageUpdaterTests : LoggingFolderCleanupTestBase
+{
+    private const string WORK_FOLDER = "/tmp/work";
+    private const string REPO_URL = "git@github.com:test/test-repo.git";
+    private const string TRACKING_FILE = "/tmp/tracking.json";
+    private const string CACHE_FILE = "/tmp/cache.json";
+    private const string TEMPLATE_REPO_URL = "git@github.com:test/template-repo.git";
+    private const string PACKAGES_FILE = "/tmp/packages.json";
+    private const string RELEASE_CONFIG_FILE = "/tmp/release.json";
+
+    private static readonly DotNetVersionSettings DefaultDotNetSettings = new(
+        SdkVersion: null,
+        AllowPreRelease: false,
+        RollForward: "latestMajor"
+    );
+
+    private static readonly ReleaseConfig DefaultReleaseConfig = new(
+        AutoReleasePendingPackages: 1,
+        MinimumHoursBeforeAutoRelease: 5,
+        InactivityHoursBeforeAutoRelease: 9,
+        NeverRelease: [],
+        AllowedAutoUpgrade: [],
+        AlwaysMatch: []
+    );
+
+    private readonly IBulkPackageConfigLoader _bulkPackageConfigLoader;
+    private readonly IDotNetBuild _dotNetBuild;
+    private readonly IDotNetFilesDetector _dotNetFilesDetector;
+    private readonly IDotNetVersion _dotNetVersion;
+    private readonly IGitRepositoryFactory _gitRepositoryFactory;
+    private readonly IGlobalJson _globalJson;
+    private readonly IPackageCache _packageCache;
+    private readonly IPackageUpdateConfigurationBuilder _packageUpdateConfigurationBuilder;
+    private readonly IPackageUpdater _packageUpdater;
+    private readonly IProjectLoader _projectLoader;
+    private readonly IReleaseConfigLoader _releaseConfigLoader;
+    private readonly IReleaseGeneration _releaseGeneration;
+    private readonly IGitRepository _repoRepository;
+    private readonly ISinglePackageUpdater _singlePackageUpdater;
+    private readonly IGitRepository _templateRepository;
+    private readonly ITrackingCache _trackingCache;
+    private readonly BulkPackageUpdater _updater;
+
+    public BulkPackageUpdaterTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._packageUpdater = GetSubstitute<IPackageUpdater>();
+        this._packageCache = GetSubstitute<IPackageCache>();
+        this._trackingCache = GetSubstitute<ITrackingCache>();
+        this._globalJson = GetSubstitute<IGlobalJson>();
+        this._dotNetVersion = GetSubstitute<IDotNetVersion>();
+        this._dotNetBuild = GetSubstitute<IDotNetBuild>();
+        this._projectLoader = GetSubstitute<IProjectLoader>();
+        this._dotNetFilesDetector = GetSubstitute<IDotNetFilesDetector>();
+        this._releaseConfigLoader = GetSubstitute<IReleaseConfigLoader>();
+        this._releaseGeneration = GetSubstitute<IReleaseGeneration>();
+        this._gitRepositoryFactory = GetSubstitute<IGitRepositoryFactory>();
+        this._bulkPackageConfigLoader = GetSubstitute<IBulkPackageConfigLoader>();
+        this._singlePackageUpdater = GetSubstitute<ISinglePackageUpdater>();
+        this._packageUpdateConfigurationBuilder = GetSubstitute<IPackageUpdateConfigurationBuilder>();
+        this._templateRepository = GetSubstitute<IGitRepository>();
+        this._repoRepository = GetSubstitute<IGitRepository>();
+
+        this._updater = new BulkPackageUpdater(
+            packageUpdater: this._packageUpdater,
+            packageCache: this._packageCache,
+            trackingCache: this._trackingCache,
+            globalJson: this._globalJson,
+            dotNetVersion: this._dotNetVersion,
+            dotNetBuild: this._dotNetBuild,
+            projectLoader: this._projectLoader,
+            dotNetFilesDetector: this._dotNetFilesDetector,
+            releaseConfigLoader: this._releaseConfigLoader,
+            releaseGeneration: this._releaseGeneration,
+            gitRepositoryFactory: this._gitRepositoryFactory,
+            bulkPackageConfigLoader: this._bulkPackageConfigLoader,
+            singlePackageUpdater: this._singlePackageUpdater,
+            packageUpdateConfigurationBuilder: this._packageUpdateConfigurationBuilder,
+            logger: this.GetTypedLogger<BulkPackageUpdater>()
+        );
+    }
+
+    private static PackageUpdateContext CreateUpdateContext(string? cacheFileName = null)
+    {
+        return new PackageUpdateContext(
+            WorkFolder: WORK_FOLDER,
+            CacheFileName: cacheFileName,
+            TrackingFileName: TRACKING_FILE,
+            AdditionalSources: [],
+            DotNetSettings: DefaultDotNetSettings,
+            ReleaseConfig: DefaultReleaseConfig
+        );
+    }
+
+    [Fact]
+    public async Task UpdateRepositoriesWithEmptyReposCompletesWithoutExceptionAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoThrowingSolutionCheckFailedExceptionContinuesAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new SolutionCheckFailedException("Solution check failed"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoThrowingDotNetBuildErrorExceptionContinuesAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new DotNetBuildErrorException("Build failed"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoThrowingReleaseTooOldExceptionContinuesAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new ReleaseTooOldException("Release too old"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoThrowingGitRepositoryLockedExceptionContinuesAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new GitRepositoryLockedException("Repo locked"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoThrowingReleaseCreatedExceptionAbortsRunAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new ReleaseCreatedException("Release created"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesCallsFinallyWithCacheAndTrackingFilesAsync()
+    {
+        PackageUpdateContext context = new(
+            WorkFolder: WORK_FOLDER,
+            CacheFileName: CACHE_FILE,
+            TrackingFileName: TRACKING_FILE,
+            AdditionalSources: [],
+            DotNetSettings: DefaultDotNetSettings,
+            ReleaseConfig: DefaultReleaseConfig
+        );
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new SolutionCheckFailedException("Solution check failed"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._packageCache.Received(1)
+            .SaveAsync(fileName: CACHE_FILE, cancellationToken: Arg.Any<CancellationToken>());
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: TRACKING_FILE, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithNullCacheFileNameDoesNotSaveCacheAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext(cacheFileName: null);
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new SolutionCheckFailedException("Solution check failed"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._packageCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithEmptyTrackingFileNameDoesNotSaveTrackingAsync()
+    {
+        PackageUpdateContext context = new(
+            WorkFolder: WORK_FOLDER,
+            CacheFileName: null,
+            TrackingFileName: string.Empty,
+            AdditionalSources: [],
+            DotNetSettings: DefaultDotNetSettings,
+            ReleaseConfig: DefaultReleaseConfig
+        );
+
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: WORK_FOLDER,
+                repoUrl: REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .ThrowsAsync(new SolutionCheckFailedException("Solution check failed"));
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [REPO_URL],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._trackingCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithNoCachedPackagesSkipsPackageUpdaterAsync()
+    {
+        PackageUpdateContext context = CreateUpdateContext();
+
+        await this._updater.UpdateRepositoriesAsync(
+            updateContext: context,
+            repositories: [],
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._packageUpdater.DidNotReceive()
+            .UpdateAsync(
+                Arg.Any<string>(),
+                Arg.Any<PackageUpdateConfiguration>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithNullCacheFileDoesNotLoadCacheAsync()
+    {
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: null,
+            trackingFileName: string.Empty,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._packageCache.DidNotReceive().LoadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithNonExistentCacheFileDoesNotLoadCacheAsync()
+    {
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        string nonExistentCache = Path.Combine(this.TempFolder, "nonexistent-cache.json");
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: nonExistentCache,
+            trackingFileName: string.Empty,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._packageCache.DidNotReceive().LoadAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithExistingCacheFileLoadsCacheAsync()
+    {
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        string cacheFile = Path.Combine(this.TempFolder, "cache.json");
+        await File.WriteAllTextAsync(path: cacheFile, contents: "[]", cancellationToken: this.CancellationToken());
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: cacheFile,
+            trackingFileName: string.Empty,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._packageCache.Received(1)
+            .LoadAsync(fileName: cacheFile, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithExistingTrackingFileLoadsTrackingAsync()
+    {
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        string trackingFile = Path.Combine(this.TempFolder, "tracking.json");
+        await File.WriteAllTextAsync(path: trackingFile, contents: "{}", cancellationToken: this.CancellationToken());
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: null,
+            trackingFileName: trackingFile,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._trackingCache.Received(1)
+            .LoadAsync(fileName: trackingFile, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public Task BulkUpdateWithMissingSdkThrowsDotNetBuildErrorExceptionAsync()
+    {
+        DotNetVersionSettings settingsWithSdk = new(
+            SdkVersion: "10.0.100",
+            AllowPreRelease: false,
+            RollForward: "latestMajor"
+        );
+
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(settingsWithSdk);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        this._packageCache.GetAll().Returns([]);
+
+        return Assert.ThrowsAsync<DotNetBuildErrorException>(() =>
+            this
+                ._updater.BulkUpdateAsync(
+                    templateRepository: TEMPLATE_REPO_URL,
+                    cacheFileName: null,
+                    trackingFileName: string.Empty,
+                    packagesFileName: PACKAGES_FILE,
+                    workFolder: this.TempFolder,
+                    releaseConfigFileName: RELEASE_CONFIG_FILE,
+                    additionalNugetSources: [],
+                    repositories: [],
+                    cancellationToken: this.CancellationToken()
+                )
+                .AsTask()
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task BulkUpdateWithCachedPackagesUpdatesCacheAsync()
+    {
+        PackageUpdate packageUpdate = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        this._templateRepository.WorkingDirectory.Returns("/template");
+        this._gitRepositoryFactory.OpenOrCloneAsync(
+                workDir: this.TempFolder,
+                repoUrl: TEMPLATE_REPO_URL,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(this._templateRepository);
+        this._bulkPackageConfigLoader.LoadAsync(
+                path: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns([packageUpdate]);
+        this._globalJson.LoadGlobalJsonAsync(
+                baseFolder: Arg.Any<string>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(DefaultDotNetSettings);
+        IReadOnlyList<System.Version> noSdks = [];
+        this._dotNetVersion.GetInstalledSdksAsync(Arg.Any<CancellationToken>()).Returns(noSdks);
+        this._releaseConfigLoader.LoadAsync(path: Arg.Any<string>(), cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(DefaultReleaseConfig);
+        IReadOnlyList<PackageVersion> cachedPackages = [new PackageVersion("Test.Package", new NuGetVersion("1.0.0"))];
+        this._packageCache.GetAll().Returns(cachedPackages);
+        this._packageUpdateConfigurationBuilder.Build(Arg.Any<PackageUpdate>())
+            .Returns(new PackageUpdateConfiguration(new PackageMatch("Test.Package", false), []));
+        this._packageUpdater.UpdateAsync(
+                Arg.Any<string>(),
+                Arg.Any<PackageUpdateConfiguration>(),
+                Arg.Any<IReadOnlyList<string>>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns([]);
+
+        await this._updater.BulkUpdateAsync(
+            templateRepository: TEMPLATE_REPO_URL,
+            cacheFileName: null,
+            trackingFileName: string.Empty,
+            packagesFileName: PACKAGES_FILE,
+            workFolder: this.TempFolder,
+            releaseConfigFileName: RELEASE_CONFIG_FILE,
+            additionalNugetSources: [],
+            repositories: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._packageCache.Received(1).Reset();
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoHavingNoChangelogSkipsWithLogAsync()
+    {
+        string repoDir = Path.Combine(this.TempFolder, "repo");
+        Directory.CreateDirectory(repoDir);
+        LibGit2Sharp.Repository.Init(repoDir);
+
+        using (LibGit2Sharp.Repository realRepo = new(repoDir))
+        {
+            this._repoRepository.Active.Returns(realRepo);
+            this._repoRepository.WorkingDirectory.Returns(repoDir);
+            this._repoRepository.ClonePath.Returns(REPO_URL);
+            this._repoRepository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+            this._repoRepository.HeadRev.Returns("abc123deadbeef");
+
+            this._gitRepositoryFactory.OpenOrCloneAsync(
+                    workDir: WORK_FOLDER,
+                    repoUrl: REPO_URL,
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(this._repoRepository);
+
+            PackageUpdateContext context = CreateUpdateContext();
+
+            await this._updater.UpdateRepositoriesAsync(
+                updateContext: context,
+                repositories: [REPO_URL],
+                packages: [],
+                cancellationToken: this.CancellationToken()
+            );
+
+            this._trackingCache.Received(1).Set(repoUrl: REPO_URL, value: "abc123deadbeef");
+        }
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoHavingChangelogButNoDotNetFilesSkipsAsync()
+    {
+        string repoDir = Path.Combine(this.TempFolder, "repo");
+        Directory.CreateDirectory(repoDir);
+        LibGit2Sharp.Repository.Init(repoDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(repoDir, "CHANGELOG.md"),
+            contents: "# Changelog",
+            cancellationToken: this.CancellationToken()
+        );
+
+        using (LibGit2Sharp.Repository realRepo = new(repoDir))
+        {
+            this._repoRepository.Active.Returns(realRepo);
+            this._repoRepository.WorkingDirectory.Returns(repoDir);
+            this._repoRepository.ClonePath.Returns(REPO_URL);
+            this._repoRepository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+            this._repoRepository.HeadRev.Returns("abc123deadbeef");
+
+            this._gitRepositoryFactory.OpenOrCloneAsync(
+                    workDir: WORK_FOLDER,
+                    repoUrl: REPO_URL,
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(this._repoRepository);
+
+            this._dotNetFilesDetector.FindAsync(baseFolder: repoDir, cancellationToken: Arg.Any<CancellationToken>())
+                .Returns(new DotNetFiles(SourceDirectory: repoDir, Solutions: [], Projects: []));
+
+            this._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: Arg.Any<string>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(DefaultDotNetSettings);
+
+            PackageUpdateContext context = CreateUpdateContext();
+
+            await this._updater.UpdateRepositoriesAsync(
+                updateContext: context,
+                repositories: [REPO_URL],
+                packages: [],
+                cancellationToken: this.CancellationToken()
+            );
+
+            this._trackingCache.Received(1).Set(repoUrl: REPO_URL, value: "abc123deadbeef");
+        }
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoHavingDotNetFilesAndNoPackagesCallsReleaseGenerationAsync()
+    {
+        string repoDir = Path.Combine(this.TempFolder, "repo");
+        Directory.CreateDirectory(repoDir);
+        LibGit2Sharp.Repository.Init(repoDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(repoDir, "CHANGELOG.md"),
+            contents: "# Changelog",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string solutionFile = Path.Combine(repoDir, "Test.sln");
+        string srcDir = Path.Combine(repoDir, "src");
+        Directory.CreateDirectory(srcDir);
+        string projectFile = Path.Combine(srcDir, "Test.csproj");
+        await File.WriteAllTextAsync(
+            path: solutionFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: projectFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+
+        using (LibGit2Sharp.Repository realRepo = new(repoDir))
+        {
+            this._repoRepository.Active.Returns(realRepo);
+            this._repoRepository.WorkingDirectory.Returns(repoDir);
+            this._repoRepository.ClonePath.Returns(REPO_URL);
+            this._repoRepository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+            this._repoRepository.HeadRev.Returns("abc123deadbeef");
+
+            this._gitRepositoryFactory.OpenOrCloneAsync(
+                    workDir: WORK_FOLDER,
+                    repoUrl: REPO_URL,
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(this._repoRepository);
+
+            this._dotNetFilesDetector.FindAsync(baseFolder: repoDir, cancellationToken: Arg.Any<CancellationToken>())
+                .Returns(new DotNetFiles(SourceDirectory: repoDir, Solutions: [solutionFile], Projects: [projectFile]));
+
+            this._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: Arg.Any<string>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(DefaultDotNetSettings);
+
+            this._dotNetBuild.LoadBuildSettingsAsync(
+                    projects: Arg.Any<IReadOnlyList<string>>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(new BuildSettings(PublishableProjects: [], PackableProjects: [], Framework: null));
+
+            PackageUpdateContext context = CreateUpdateContext();
+
+            await this._updater.UpdateRepositoriesAsync(
+                updateContext: context,
+                repositories: [REPO_URL],
+                packages: [],
+                cancellationToken: this.CancellationToken()
+            );
+
+            await this
+                ._releaseGeneration.Received(1)
+                .TryCreateNextPatchAsync(
+                    repoContext: Arg.Any<Credfeto.DotNet.Repo.Tools.Models.RepoContext>(),
+                    dotNetFiles: Arg.Any<DotNetFiles>(),
+                    buildSettings: Arg.Any<BuildSettings>(),
+                    dotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                    packages: Arg.Any<IReadOnlyList<PackageUpdate>>(),
+                    releaseConfig: Arg.Any<ReleaseConfig>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                );
+        }
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateRepositoriesWithRepoHavingDotNetFilesAndPackagesResetsProjectLoaderAsync()
+    {
+        string repoDir = Path.Combine(this.TempFolder, "repo");
+        Directory.CreateDirectory(repoDir);
+        LibGit2Sharp.Repository.Init(repoDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(repoDir, "CHANGELOG.md"),
+            contents: "# Changelog",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string solutionFile = Path.Combine(repoDir, "Test.sln");
+        string srcDir = Path.Combine(repoDir, "src");
+        Directory.CreateDirectory(srcDir);
+        string projectFile = Path.Combine(srcDir, "Test.csproj");
+        await File.WriteAllTextAsync(
+            path: solutionFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+        await File.WriteAllTextAsync(
+            path: projectFile,
+            contents: string.Empty,
+            cancellationToken: this.CancellationToken()
+        );
+
+        PackageUpdate packageUpdate = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        using (LibGit2Sharp.Repository realRepo = new(repoDir))
+        {
+            this._repoRepository.Active.Returns(realRepo);
+            this._repoRepository.WorkingDirectory.Returns(repoDir);
+            this._repoRepository.ClonePath.Returns(REPO_URL);
+            this._repoRepository.GetDefaultBranch(GitConstants.Upstream).Returns("main");
+            this._repoRepository.HeadRev.Returns("abc123deadbeef");
+
+            this._gitRepositoryFactory.OpenOrCloneAsync(
+                    workDir: WORK_FOLDER,
+                    repoUrl: REPO_URL,
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(this._repoRepository);
+
+            this._dotNetFilesDetector.FindAsync(baseFolder: repoDir, cancellationToken: Arg.Any<CancellationToken>())
+                .Returns(new DotNetFiles(SourceDirectory: repoDir, Solutions: [solutionFile], Projects: [projectFile]));
+
+            this._globalJson.LoadGlobalJsonAsync(
+                    baseFolder: Arg.Any<string>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(DefaultDotNetSettings);
+
+            this._dotNetBuild.LoadBuildSettingsAsync(
+                    projects: Arg.Any<IReadOnlyList<string>>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(new BuildSettings(PublishableProjects: [], PackableProjects: [], Framework: null));
+
+            this._singlePackageUpdater.UpdateAsync(
+                    updateContext: Arg.Any<PackageUpdateContext>(),
+                    repoContext: Arg.Any<Credfeto.DotNet.Repo.Tools.Models.RepoContext>(),
+                    solutions: Arg.Any<IReadOnlyList<string>>(),
+                    sourceDirectory: Arg.Any<string>(),
+                    buildSettings: Arg.Any<BuildSettings>(),
+                    dotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                    package: Arg.Any<PackageUpdate>(),
+                    cancellationToken: Arg.Any<CancellationToken>()
+                )
+                .Returns(false);
+
+            PackageUpdateContext context = CreateUpdateContext();
+
+            await this._updater.UpdateRepositoriesAsync(
+                updateContext: context,
+                repositories: [REPO_URL],
+                packages: [packageUpdate],
+                cancellationToken: this.CancellationToken()
+            );
+
+            this._projectLoader.Received(1).Reset();
+        }
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/PackageUpdateConfigurationBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/PackageUpdateConfigurationBuilderTests.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections.Generic;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
+using Credfeto.DotNet.Repo.Tools.Packages.Services;
+using Credfeto.Package;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Services;
+
+public sealed class PackageUpdateConfigurationBuilderTests : LoggingFolderCleanupTestBase
+{
+    private readonly IPackageUpdateConfigurationBuilder _builder;
+
+    public PackageUpdateConfigurationBuilderTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._builder = new PackageUpdateConfigurationBuilder(
+            logger: this.GetTypedLogger<PackageUpdateConfigurationBuilder>()
+        );
+    }
+
+    [Fact]
+    public void BuildWithNoExcludesReturnsCorrectPackageMatch()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Equal(expected: "Test.Package", actual: result.PackageMatch.PackageId);
+    }
+
+    [Fact]
+    public void BuildWithNoExcludesUsesPrefix()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.True(result.PackageMatch.Prefix, userMessage: "Prefix should be true when ExactMatch is false");
+    }
+
+    [Fact]
+    public void BuildWithExactMatchDoesNotUsePrefix()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: true,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.False(result.PackageMatch.Prefix, userMessage: "Prefix should be false when ExactMatch is true");
+    }
+
+    [Fact]
+    public void BuildWithNoExcludesReturnsEmptyExcludedPackages()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Empty(result.ExcludedPackages);
+    }
+
+    [Fact]
+    public void BuildWithEmptyExcludesReturnsEmptyExcludedPackages()
+    {
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: []
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Empty(result.ExcludedPackages);
+    }
+
+    [Fact]
+    public void BuildWithExcludesReturnsCorrectExcludedPackageCount()
+    {
+        PackageExclude exclude = new(packageId: "Excluded.Package", exactMatch: false);
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: [exclude]
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Single(result.ExcludedPackages);
+    }
+
+    [Fact]
+    public void BuildWithExcludesReturnsCorrectExcludedPackageId()
+    {
+        PackageExclude exclude = new(packageId: "Excluded.Package", exactMatch: false);
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: [exclude]
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Equal(expected: "Excluded.Package", actual: result.ExcludedPackages[0].PackageId);
+    }
+
+    [Fact]
+    public void BuildWithExactMatchExcludeDoesNotUsePrefix()
+    {
+        PackageExclude exclude = new(packageId: "Excluded.Package", exactMatch: true);
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: [exclude]
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.False(result.ExcludedPackages[0].Prefix, userMessage: "Prefix should be false when ExactMatch is true");
+    }
+
+    [Fact]
+    public void BuildWithMultipleExcludesReturnsAllExcludedPackages()
+    {
+        IReadOnlyList<PackageExclude> excludes =
+        [
+            new PackageExclude(packageId: "Excluded.A", exactMatch: false),
+            new PackageExclude(packageId: "Excluded.B", exactMatch: true),
+        ];
+
+        PackageUpdate package = new(
+            packageId: "Test.Package",
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: excludes
+        );
+
+        PackageUpdateConfiguration result = this._builder.Build(package);
+
+        Assert.Equal(expected: 2, actual: result.ExcludedPackages.Count);
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/SinglePackageUpdaterTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Services/SinglePackageUpdaterTests.cs
@@ -1,0 +1,591 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces.Exceptions;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Models;
+using Credfeto.DotNet.Repo.Tools.Models.Packages;
+using Credfeto.DotNet.Repo.Tools.Packages.Services;
+using Credfeto.DotNet.Repo.Tracking.Interfaces;
+using Credfeto.Package;
+using FunFair.Test.Common;
+using NSubstitute;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests.Services;
+
+public sealed class SinglePackageUpdaterTests : LoggingFolderCleanupTestBase
+{
+    private const string CLONE_PATH = "git@github.com:test/test-repo.git";
+    private const string DEFAULT_BRANCH = "main";
+    private const string HEAD_REV = "abc123def456";
+
+    private static readonly DotNetVersionSettings DefaultDotNetSettings = new(
+        SdkVersion: null,
+        AllowPreRelease: false,
+        RollForward: "latestMajor"
+    );
+
+    private static readonly BuildSettings EmptyBuildSettings = new(
+        PublishableProjects: [],
+        PackableProjects: [],
+        Framework: null
+    );
+
+    private readonly IDotNetBuild _dotNetBuild;
+    private readonly IDotNetSolutionCheck _dotNetSolutionCheck;
+    private readonly IPackageUpdateConfigurationBuilder _packageUpdateConfigurationBuilder;
+    private readonly IPackageUpdater _packageUpdater;
+    private readonly IGitRepository _repository;
+    private readonly ISinglePackageUpdater _singlePackageUpdater;
+    private readonly ITrackingCache _trackingCache;
+    private readonly ITrackingHashGenerator _trackingHashGenerator;
+
+    public SinglePackageUpdaterTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._dotNetSolutionCheck = GetSubstitute<IDotNetSolutionCheck>();
+        this._dotNetBuild = GetSubstitute<IDotNetBuild>();
+        this._trackingCache = GetSubstitute<ITrackingCache>();
+        this._trackingHashGenerator = GetSubstitute<ITrackingHashGenerator>();
+        this._packageUpdater = GetSubstitute<IPackageUpdater>();
+        this._packageUpdateConfigurationBuilder = GetSubstitute<IPackageUpdateConfigurationBuilder>();
+
+        this._repository = GetSubstitute<IGitRepository>();
+        this._repository.ClonePath.Returns(CLONE_PATH);
+        this._repository.WorkingDirectory.Returns(this.TempFolder);
+        this._repository.GetDefaultBranch(GitConstants.Upstream).Returns(DEFAULT_BRANCH);
+        this._repository.HeadRev.Returns(HEAD_REV);
+
+        this._singlePackageUpdater = new SinglePackageUpdater(
+            dotNetSolutionCheck: this._dotNetSolutionCheck,
+            dotNetBuild: this._dotNetBuild,
+            trackingCache: this._trackingCache,
+            trackingHashGenerator: this._trackingHashGenerator,
+            packageUpdater: this._packageUpdater,
+            packageUpdateConfigurationBuilder: this._packageUpdateConfigurationBuilder,
+            logger: this.GetTypedLogger<SinglePackageUpdater>()
+        );
+    }
+
+    private async Task<string> CreateChangelogFileAsync()
+    {
+        string changelogPath = Path.Combine(path1: this.TempFolder, path2: "CHANGELOG.md");
+        const string content = """
+            # Changelog
+            All notable changes to this project will be documented in this file.
+
+            ## [Unreleased]
+            ### Changed
+
+            ## [0.0.1] - 2024-01-01
+            ### Changed
+            - Initial release
+            """;
+        await File.WriteAllTextAsync(
+            path: changelogPath,
+            contents: content,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken: this.CancellationToken()
+        );
+
+        return changelogPath;
+    }
+
+    private RepoContext CreateRepoContext(string changelogFileName)
+    {
+        return new RepoContext(
+            ClonePath: CLONE_PATH,
+            Repository: this._repository,
+            WorkingDirectory: this.TempFolder,
+            DefaultBranch: DEFAULT_BRANCH,
+            ChangeLogFileName: changelogFileName
+        );
+    }
+
+    private static PackageUpdateContext CreateUpdateContext()
+    {
+        return new PackageUpdateContext(
+            WorkFolder: "/tmp/work",
+            CacheFileName: null,
+            TrackingFileName: "/tmp/tracking.json",
+            AdditionalSources: [],
+            DotNetSettings: DefaultDotNetSettings,
+            ReleaseConfig: new(
+                AutoReleasePendingPackages: 1,
+                MinimumHoursBeforeAutoRelease: 5,
+                InactivityHoursBeforeAutoRelease: 9,
+                NeverRelease: [],
+                AllowedAutoUpgrade: [],
+                AlwaysMatch: []
+            )
+        );
+    }
+
+    private static PackageUpdate CreatePackage(string packageId = "Test.Package")
+    {
+        return new PackageUpdate(
+            packageId: packageId,
+            packageType: "nuget",
+            exactMatch: false,
+            versionBumpPackage: false,
+            prohibitVersionBumpWhenReferenced: false,
+            exclude: null
+        );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithNoUncommittedChangesAndMatchingTrackingHashAndNoPackageUpdatesReturnsFalseAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        // No uncommitted changes
+        this._repository.HasUncommittedChanges().Returns(false);
+
+        // Tracking hash matches HeadRev - so no build required
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        // No package updates
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+        IReadOnlyList<PackageVersion> noPackageUpdates = [];
+        this._packageUpdater.UpdateAsync(
+                basePath: this.TempFolder,
+                configuration: config,
+                packageSources: updateContext.AdditionalSources,
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(noPackageUpdates);
+
+        bool result = await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.False(result, userMessage: "Update should return false when no packages were updated");
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithNoPackageUpdatesRemovesBranchesForPackageAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+        IReadOnlyList<PackageVersion> noPackageUpdates = [];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(noPackageUpdates);
+
+        await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._repository.Received(1)
+            .RemoveBranchesForPrefixAsync(
+                branchForUpdate: Arg.Any<string>(),
+                branchPrefix: Arg.Is<string>(s => s.Contains("test.package")),
+                upstream: GitConstants.Upstream,
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithUncommittedChangesResetsToDefaultBranchBeforeProcessingAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        // Has uncommitted changes
+        this._repository.HasUncommittedChanges().Returns(true);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+        IReadOnlyList<PackageVersion> noPackageUpdates = [];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(noPackageUpdates);
+
+        await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this
+            ._repository.Received(2)
+            .ResetToDefaultBranchAsync(
+                upstream: GitConstants.Upstream,
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithNullTrackingHashRunsBuildAndUpdatesHashAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+
+        // No prior tracking hash
+        this._trackingCache.Get(CLONE_PATH).Returns((string?)null);
+        this._trackingHashGenerator.GenerateTrackingHashAsync(
+                repoContext: Arg.Any<RepoContext>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns("newhash123");
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+        IReadOnlyList<PackageVersion> noPackageUpdates = [];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(noPackageUpdates);
+
+        await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        await this._dotNetBuild.Received(1).BuildAsync(Arg.Any<BuildContext>(), Arg.Any<CancellationToken>());
+        await this
+            ._trackingHashGenerator.Received(1)
+            .GenerateTrackingHashAsync(
+                repoContext: Arg.Any<RepoContext>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            );
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithPackageUpdatesAndPostCheckReturnsFalseReturnsTrueAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+
+        // Return one update
+        PackageVersion updatedPackage = new(packageId: "Test.Package", version: new NuGetVersion(1, 2, 3));
+        IReadOnlyList<PackageVersion> packageUpdates = [updatedPackage];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(packageUpdates);
+
+        // PostCheck returns false - so don't build
+        this._dotNetSolutionCheck.PostCheckAsync(
+                solutions: Arg.Any<IReadOnlyList<string>>(),
+                repositoryDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                templateDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(false);
+
+        // Branch doesn't exist
+        this._repository.DoesBranchExist(Arg.Any<string>()).Returns(false);
+
+        bool result = await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Update should return true when packages were updated");
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithPackageUpdatesAndPostCheckBuildErrorReturnsTrueAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+
+        PackageVersion updatedPackage = new(packageId: "Test.Package", version: new NuGetVersion(1, 2, 3));
+        IReadOnlyList<PackageVersion> packageUpdates = [updatedPackage];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(packageUpdates);
+
+        // PostCheck returns true, then build throws
+        this._dotNetSolutionCheck.PostCheckAsync(
+                solutions: Arg.Any<IReadOnlyList<string>>(),
+                repositoryDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                templateDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+
+        this._dotNetBuild.When(async x => await x.BuildAsync(Arg.Any<BuildContext>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new DotNetBuildErrorException("Build failed after package update"));
+
+        // Branch doesn't exist
+        this._repository.DoesBranchExist(Arg.Any<string>()).Returns(false);
+
+        bool result = await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        // Returns true (update was made, even though build failed - it commits to named branch)
+        Assert.True(result, userMessage: "Update should return true when packages were updated even if build failed");
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithPackageUpdatesWhenBranchAlreadyExistsLogsSkipAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+
+        PackageVersion updatedPackage = new(packageId: "Test.Package", version: new NuGetVersion(1, 2, 3));
+        IReadOnlyList<PackageVersion> packageUpdates = [updatedPackage];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(packageUpdates);
+
+        // PostCheck returns false (build not ok)
+        this._dotNetSolutionCheck.PostCheckAsync(
+                solutions: Arg.Any<IReadOnlyList<string>>(),
+                repositoryDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                templateDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(false);
+
+        // Branch already exists
+        this._repository.DoesBranchExist(Arg.Any<string>()).Returns(true);
+
+        bool result = await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Update should return true when packages were updated");
+        // Branch creation should not be called since it already exists
+        await this._repository.DidNotReceive().CreateBranchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0051: Method is too long",
+        Justification = "Unit Test"
+    )]
+    public async Task UpdateWithPackageUpdatesAndBuildOkCommitsToDefaultBranchAsync()
+    {
+        string changelogPath = await this.CreateChangelogFileAsync();
+        RepoContext repoContext = this.CreateRepoContext(changelogPath);
+        PackageUpdateContext updateContext = CreateUpdateContext();
+        PackageUpdate package = CreatePackage();
+
+        this._repository.HasUncommittedChanges().Returns(false);
+        this._trackingCache.Get(CLONE_PATH).Returns(HEAD_REV);
+        this._trackingHashGenerator.GenerateTrackingHashAsync(
+                repoContext: Arg.Any<RepoContext>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns("newhash");
+
+        PackageUpdateConfiguration config = new(
+            PackageMatch: new PackageMatch(PackageId: "Test.Package", Prefix: true),
+            ExcludedPackages: []
+        );
+        this._packageUpdateConfigurationBuilder.Build(package).Returns(config);
+
+        PackageVersion updatedPackage = new(packageId: "Test.Package", version: new NuGetVersion(1, 2, 3));
+        IReadOnlyList<PackageVersion> packageUpdates = [updatedPackage];
+        this._packageUpdater.UpdateAsync(
+                basePath: Arg.Any<string>(),
+                configuration: Arg.Any<PackageUpdateConfiguration>(),
+                packageSources: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(packageUpdates);
+
+        // PostCheck returns true, build succeeds
+        this._dotNetSolutionCheck.PostCheckAsync(
+                solutions: Arg.Any<IReadOnlyList<string>>(),
+                repositoryDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                templateDotNetSettings: Arg.Any<DotNetVersionSettings>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(true);
+
+        bool result = await this._singlePackageUpdater.UpdateAsync(
+            updateContext: updateContext,
+            repoContext: repoContext,
+            solutions: [],
+            sourceDirectory: this.TempFolder,
+            buildSettings: EmptyBuildSettings,
+            dotNetSettings: DefaultDotNetSettings,
+            package: package,
+            cancellationToken: this.CancellationToken()
+        );
+
+        Assert.True(result, userMessage: "Update should return true when packages were updated and build succeeded");
+        await this._repository.Received(1).PushAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/TrackingCacheExtensionsTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/TrackingCacheExtensionsTests.cs
@@ -1,0 +1,129 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Models;
+using Credfeto.DotNet.Repo.Tools.Release.Interfaces;
+using Credfeto.DotNet.Repo.Tracking.Interfaces;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Packages.Tests;
+
+public sealed class TrackingCacheExtensionsTests : TestBase
+{
+    private const string CLONE_PATH = "git@github.com:test/test-repo.git";
+    private const string DEFAULT_BRANCH = "main";
+    private const string TRACKING_FILE = "/tmp/tracking.json";
+
+    private static readonly DotNetVersionSettings DefaultDotNetSettings = new(
+        SdkVersion: null,
+        AllowPreRelease: false,
+        RollForward: "latestMajor"
+    );
+
+    private static readonly ReleaseConfig DefaultReleaseConfig = new(
+        AutoReleasePendingPackages: 1,
+        MinimumHoursBeforeAutoRelease: 5,
+        InactivityHoursBeforeAutoRelease: 9,
+        NeverRelease: [],
+        AllowedAutoUpgrade: [],
+        AlwaysMatch: []
+    );
+
+    private readonly IGitRepository _repository;
+    private readonly RepoContext _repoContext;
+    private readonly ITrackingCache _trackingCache;
+
+    public TrackingCacheExtensionsTests()
+    {
+        this._trackingCache = GetSubstitute<ITrackingCache>();
+        this._repository = GetSubstitute<IGitRepository>();
+        this._repository.ClonePath.Returns(CLONE_PATH);
+        this._repository.WorkingDirectory.Returns("/tmp/work");
+        this._repository.GetDefaultBranch(GitConstants.Upstream).Returns(DEFAULT_BRANCH);
+
+        this._repoContext = new RepoContext(Repository: this._repository, ChangeLogFileName: "CHANGELOG.md");
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithNonEmptyTrackingFileNameCallsSetAndSaveAsync()
+    {
+        PackageUpdateContext updateContext = CreateUpdateContext(trackingFileName: TRACKING_FILE);
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: "some-value",
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: "some-value");
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: TRACKING_FILE, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithEmptyTrackingFileNameCallsSetButNotSaveAsync()
+    {
+        PackageUpdateContext updateContext = CreateUpdateContext(trackingFileName: string.Empty);
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: "some-value",
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: "some-value");
+        await this._trackingCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithNullValueCallsSetWithNullAsync()
+    {
+        PackageUpdateContext updateContext = CreateUpdateContext(trackingFileName: TRACKING_FILE);
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: null,
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: null);
+        await this
+            ._trackingCache.Received(1)
+            .SaveAsync(fileName: TRACKING_FILE, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateTrackingWithWhiteSpaceTrackingFileNameCallsSetButNotSaveAsync()
+    {
+        PackageUpdateContext updateContext = CreateUpdateContext(trackingFileName: "   ");
+
+        await this._trackingCache.UpdateTrackingAsync(
+            repoContext: this._repoContext,
+            updateContext: updateContext,
+            value: "some-value",
+            cancellationToken: this.CancellationToken()
+        );
+
+        this._trackingCache.Received(1).Set(repoUrl: CLONE_PATH, value: "some-value");
+        await this._trackingCache.DidNotReceive().SaveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private static PackageUpdateContext CreateUpdateContext(string trackingFileName)
+    {
+        return new PackageUpdateContext(
+            WorkFolder: "/tmp/work",
+            CacheFileName: null,
+            TrackingFileName: trackingFileName,
+            AdditionalSources: [],
+            DotNetSettings: DefaultDotNetSettings,
+            ReleaseConfig: DefaultReleaseConfig
+        );
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Packages/InternalsVisibleTo.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages/InternalsVisibleTo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Credfeto.DotNet.Repo.Tools.Packages.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
## Summary

- Adds unit tests to achieve 100% code coverage for the `Credfeto.DotNet.Repo.Tools.Packages` assembly
- Tests cover exception constructors, branch naming logic, package update configuration builder, tracking cache extensions, and package config loading from file

Closes #146

## Test plan

- [ ] All tests pass
- [ ] Code coverage reaches 100% for the `Credfeto.DotNet.Repo.Tools.Packages` assembly
- [ ] Build passes with no warnings