### PR TITLE
fix: treat corrupt tracking.json as empty rather than crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 - Add unit tests for 100% code coverage: Credfeto.DotNet.Repo.Tools.Git
 ### Fixed
+- Corrupt tracking.json no longer causes fatal exit - it is now treated as empty
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Credfeto.DotNet.Repo.Tracking.Tests/Services/TrackingCacheTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tracking.Tests/Services/TrackingCacheTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Credfeto.DotNet.Repo.Tracking.Interfaces;
 using Credfeto.DotNet.Repo.Tracking.Services;
@@ -225,7 +224,7 @@ public sealed class TrackingCacheTests : LoggingFolderCleanupTestBase
     }
 
     [Fact]
-    public async Task LoadJsonArrayThrowsAsync()
+    public async Task LoadJsonArrayTreatsAsEmptyAsync()
     {
         string trackingFile = Path.Combine(path1: this.TempFolder, $"{NewId}.json");
         this.Output.WriteLine(trackingFile);
@@ -236,13 +235,14 @@ public sealed class TrackingCacheTests : LoggingFolderCleanupTestBase
             cancellationToken: this.CancellationToken()
         );
 
-        await Assert.ThrowsAsync<JsonException>(() =>
-            this._trackingCache.LoadAsync(fileName: trackingFile, this.CancellationToken()).AsTask()
-        );
+        await this._trackingCache.LoadAsync(fileName: trackingFile, cancellationToken: this.CancellationToken());
+
+        string? result = this._trackingCache.Get("Test1");
+        Assert.Null(result);
     }
 
     [Fact]
-    public async Task LoadJsonWithNullValueThrowsAsync()
+    public async Task LoadJsonWithNullValueTreatsAsEmptyAsync()
     {
         string trackingFile = Path.Combine(path1: this.TempFolder, $"{NewId}.json");
         this.Output.WriteLine(trackingFile);
@@ -253,8 +253,32 @@ public sealed class TrackingCacheTests : LoggingFolderCleanupTestBase
             cancellationToken: this.CancellationToken()
         );
 
-        await Assert.ThrowsAsync<JsonException>(() =>
-            this._trackingCache.LoadAsync(fileName: trackingFile, this.CancellationToken()).AsTask()
+        await this._trackingCache.LoadAsync(fileName: trackingFile, cancellationToken: this.CancellationToken());
+
+        string? result = this._trackingCache.Get("key");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task LoadCorruptJsonWritesValidFileOnNextSaveAsync()
+    {
+        string trackingFile = Path.Combine(path1: this.TempFolder, $"{NewId}.json");
+        this.Output.WriteLine(trackingFile);
+
+        await File.WriteAllTextAsync(
+            path: trackingFile,
+            contents: "NOT VALID JSON",
+            cancellationToken: this.CancellationToken()
         );
+
+        await this._trackingCache.LoadAsync(fileName: trackingFile, cancellationToken: this.CancellationToken());
+
+        string? result = this._trackingCache.Get("Test1");
+        Assert.Null(result);
+
+        await this._trackingCache.SaveAsync(fileName: trackingFile, cancellationToken: this.CancellationToken());
+
+        string content = await File.ReadAllTextAsync(path: trackingFile, cancellationToken: this.CancellationToken());
+        Assert.Equal(expected: "{}", actual: content);
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tracking/Services/LoggingExtensions/TrackingCacheLoggingExtensions.cs
+++ b/src/Credfeto.DotNet.Repo.Tracking/Services/LoggingExtensions/TrackingCacheLoggingExtensions.cs
@@ -40,4 +40,11 @@ internal static partial class TrackingCacheLoggingExtensions
         string existing,
         string version
     );
+
+    [LoggerMessage(
+        EventId = 4,
+        Level = LogLevel.Warning,
+        Message = "[TRACKING] Corrupt tracking file {fileName} - treating as empty"
+    )]
+    public static partial void CorruptTrackingFile(this ILogger<TrackingCache> logger, string fileName);
 }

--- a/src/Credfeto.DotNet.Repo.Tracking/Services/TrackingCache.cs
+++ b/src/Credfeto.DotNet.Repo.Tracking/Services/TrackingCache.cs
@@ -36,7 +36,19 @@ public sealed class TrackingCache : ITrackingCache
 
         string content = await File.ReadAllTextAsync(path: fileName, cancellationToken: cancellationToken);
 
-        TrackingItems? items = JsonSerializer.Deserialize(json: content, jsonTypeInfo: this._typeInfo);
+        TrackingItems? items;
+
+        try
+        {
+            items = JsonSerializer.Deserialize(json: content, jsonTypeInfo: this._typeInfo);
+        }
+        catch (JsonException)
+        {
+            this._logger.CorruptTrackingFile(fileName);
+            this._changed = true;
+
+            return;
+        }
 
         if (items is not null)
         {


### PR DESCRIPTION
## Summary

- Catch `JsonException` in `TrackingCache.LoadAsync` and treat corrupt `tracking.json` as an empty cache instead of crashing
- Log a `Warning` when a corrupt file is detected so the problem is still surfaced
- Set `_changed = true` on corruption so the next save writes a valid empty file
- Update existing tests that expected `JsonException` to verify the new graceful behaviour
- Add `LoadCorruptJsonWritesValidFileOnNextSaveAsync` test to verify the recovery path end-to-end

Closes #205

## Test plan

- [ ] `LoadJsonArrayTreatsAsEmptyAsync` — array content silently yields empty cache
- [ ] `LoadJsonWithNullValueTreatsAsEmptyAsync` — null-value content silently yields empty cache
- [ ] `LoadCorruptJsonWritesValidFileOnNextSaveAsync` — corrupt file is overwritten with `{}` on next save
- [ ] All existing tracking tests still pass