### PR TITLE
fix: generate yamllint-conforming dependabot.yml (document-start, indented sequences)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Also check for .razor files when determining if project needs Microsoft.NET.Sdk.Razor SDK
 - Removed InternalsVisibleTo usage (banned by new FFS0051 analyzer rule) by making test-exercised internal types public and retiring redundant tests of source-generated JSON serializer contexts
 - Made GitCommandLine and GitRepository public in Credfeto.DotNet.Repo.Tools.Git to remove InternalsVisibleTo usage
+- Generate .github/dependabot.yml with yamllint-conforming YAML (document-start marker and indented block sequences) so the file no longer fights the linter on every commit
 ### Changed
 - Updated FunFair.CodeAnalysis to 7.2.6.2145 across all projects
 ### Deprecated

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
@@ -116,6 +116,56 @@ public sealed class DependaBotConfigBuilderTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
+    public async Task GeneratesYamllintConformingDocument()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: this._tempFolder,
+            dotNetFiles: DotNetFilesWithSolutionsAndProjects(),
+            packages: [ExactPackage("FunFair.Test.Common"), WildcardPackage("Meziantou")],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+
+        string expected = string.Join(
+            separator: Environment.NewLine,
+            values:
+            [
+                "---",
+                "version: 2",
+                "updates:",
+                "",
+                "  - package-ecosystem: nuget",
+                "    directory: \"/\"",
+                "    schedule:",
+                "      interval: daily",
+                "      time: \"03:00\"",
+                "      timezone: \"Europe/London\"",
+                "    open-pull-requests-limit: 99",
+                "    assignees:",
+                "      - credfeto",
+                "    commit-message:",
+                "      prefix: \"[Dependencies]\"",
+                "    labels:",
+                "      - \"nuget\"",
+                "      - \"dependencies\"",
+                "      - \"Changelog Not Required\"",
+                "    allow:",
+                "      - dependency-type: all",
+                "    ignore:",
+                "      - dependency-name: \"FunFair.Test.Common\"",
+                "      - dependency-name: \"Meziantou.*\"",
+            ]
+        );
+
+        Assert.Equal(expected: expected, actual: result, StringComparer.Ordinal);
+    }
+
+    [Fact]
     public async Task WithSubmodulesGeneratesGitSubmoduleSection()
     {
         IGitRepository repository = this.CreateRepository(hasSubmodules: true);

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/DependaBotConfigBuilder.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/DependaBotConfigBuilder.cs
@@ -21,19 +21,24 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
         this._logger = logger;
     }
 
-    
-    public ValueTask<string> BuildDependabotConfigAsync(RepoContext repoContext,
-                                                        string templateFolder,
-                                                        DotNetFiles dotNetFiles,
-                                                        IReadOnlyList<PackageUpdate> packages,
-                                                        CancellationToken cancellationToken)
+    public ValueTask<string> BuildDependabotConfigAsync(
+        RepoContext repoContext,
+        string templateFolder,
+        DotNetFiles dotNetFiles,
+        IReadOnlyList<PackageUpdate> packages,
+        CancellationToken cancellationToken
+    )
     {
-        List<string> config = ["version: 2", "updates:"];
+        List<string> config = ["---", "version: 2", "updates:"];
 
         if (repoContext.HasSubModules())
         {
-            this.AddBaseConfig(config: config, ecoSystem: "gitsubmodule", directory: "/", packageTypeLabel: "submodule", reviewer: "credfeto");
-            AllowAllDependencies(config);
+            this.AddEcosystemSection(
+                config: config,
+                ecoSystem: "gitsubmodule",
+                directory: "/",
+                packageTypeLabel: "submodule"
+            );
         }
 
         if (dotNetFiles.HasSolutionsAndProjects)
@@ -45,36 +50,62 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
         {
             foreach (string dir in directories)
             {
-                this.AddBaseConfig(config: config, ecoSystem: "npm", directory: dir, packageTypeLabel: "npm", reviewer: "credfeto");
-                config.Add("  versioning-strategy: increase-if-necessary");
+                this.AddBaseConfig(
+                    config: config,
+                    ecoSystem: "npm",
+                    directory: dir,
+                    packageTypeLabel: "npm",
+                    reviewer: "credfeto"
+                );
+                config.Add("    versioning-strategy: increase-if-necessary");
                 AllowAllDependencies(config);
             }
         }
 
         if (repoContext.HasDockerFiles())
         {
-            this.AddBaseConfig(config: config, ecoSystem: "docker", directory: "/", packageTypeLabel: "docker", reviewer: "credfeto");
-            AllowAllDependencies(config);
+            this.AddEcosystemSection(config: config, ecoSystem: "docker", directory: "/", packageTypeLabel: "docker");
         }
 
         if (repoContext.HasNonStandardGithubActions(templateFolder))
         {
-            this.AddBaseConfig(config: config, ecoSystem: "github-actions", directory: "/", packageTypeLabel: "github-actions", reviewer: "credfeto");
-            AllowAllDependencies(config);
+            this.AddEcosystemSection(
+                config: config,
+                ecoSystem: "github-actions",
+                directory: "/",
+                packageTypeLabel: "github-actions"
+            );
         }
 
         if (repoContext.HasPython())
         {
-            this.AddBaseConfig(config: config, ecoSystem: "pip", directory: "/", packageTypeLabel: "python", reviewer: "credfeto");
-            AllowAllDependencies(config);
+            this.AddEcosystemSection(config: config, ecoSystem: "pip", directory: "/", packageTypeLabel: "python");
         }
 
         return ValueTask.FromResult(string.Join(separator: Environment.NewLine, values: config));
     }
 
+    private void AddEcosystemSection(List<string> config, string ecoSystem, string directory, string packageTypeLabel)
+    {
+        this.AddBaseConfig(
+            config: config,
+            ecoSystem: ecoSystem,
+            directory: directory,
+            packageTypeLabel: packageTypeLabel,
+            reviewer: "credfeto"
+        );
+        AllowAllDependencies(config);
+    }
+
     private void AddDotNetConfig(List<string> config, IReadOnlyList<PackageUpdate> packages)
     {
-        this.AddBaseConfig(config: config, ecoSystem: "nuget", directory: "/", packageTypeLabel: "nuget", reviewer: "credfeto");
+        this.AddBaseConfig(
+            config: config,
+            ecoSystem: "nuget",
+            directory: "/",
+            packageTypeLabel: "nuget",
+            reviewer: "credfeto"
+        );
         AllowAllDependencies(config);
 
         if (packages is [])
@@ -83,7 +114,7 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
         }
 
         // Add packages to ignore
-        config.Add("  ignore:");
+        config.Add("    ignore:");
 
         IReadOnlyList<PackageUpdate> packagesToAdd =
         [
@@ -91,9 +122,13 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
                 .OrderBy(keySelector: p => p.PackageId, comparer: StringComparer.OrdinalIgnoreCase),
         ];
 
-        config.AddRange(packagesToAdd.Select(package => package.ExactMatch
-                                                 ? $"  - dependency-name: \"{package.PackageId}\""
-                                                 : $"  - dependency-name: \"{package.PackageId}.*\""));
+        config.AddRange(
+            packagesToAdd.Select(package =>
+                package.ExactMatch
+                    ? $"      - dependency-name: \"{package.PackageId}\""
+                    : $"      - dependency-name: \"{package.PackageId}.*\""
+            )
+        );
     }
 
     private static IEnumerable<PackageUpdate> DetermineMinimalDotnetPackages(IReadOnlyList<PackageUpdate> packages)
@@ -101,8 +136,11 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
         // Add Wildcard packages
         List<string> wildcardPackages = [];
 
-        foreach (PackageUpdate package in packages.Where(package => !package.ExactMatch)
-                                                  .OrderBy(package => package.PackageId.Length))
+        foreach (
+            PackageUpdate package in packages
+                .Where(package => !package.ExactMatch)
+                .OrderBy(package => package.PackageId.Length)
+        )
         {
             if (wildcardPackages.Exists(candidate => IsWildcardMatch(package: package, wildcardPackage: candidate)))
             {
@@ -117,8 +155,11 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
         // Add exact match packages
         HashSet<string> exactPackages = new(StringComparer.OrdinalIgnoreCase);
 
-        foreach (PackageUpdate package in packages.Where(package => package.ExactMatch)
-                                                  .OrderBy(package => package.PackageId.Length))
+        foreach (
+            PackageUpdate package in packages
+                .Where(package => package.ExactMatch)
+                .OrderBy(package => package.PackageId.Length)
+        )
         {
             if (wildcardPackages.Exists(candidate => IsWildcardMatch(package: package, wildcardPackage: candidate)))
             {
@@ -138,37 +179,45 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
 
     private static bool IsWildcardMatch(PackageUpdate package, string wildcardPackage)
     {
-        return StringComparer.OrdinalIgnoreCase.Equals(x: package.PackageId, y: wildcardPackage) ||
-               package.PackageId.StartsWith(wildcardPackage + ".", comparisonType: StringComparison.OrdinalIgnoreCase);
+        return StringComparer.OrdinalIgnoreCase.Equals(x: package.PackageId, y: wildcardPackage)
+            || package.PackageId.StartsWith(wildcardPackage + ".", comparisonType: StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AllowAllDependencies(List<string> config)
     {
         // allow all packages
-        config.AddRange(["  allow:", "  - dependency-type: all"]);
+        config.AddRange(["    allow:", "      - dependency-type: all"]);
     }
 
-    private void AddBaseConfig(List<string> config, string ecoSystem, string directory, string packageTypeLabel, string reviewer)
+    private void AddBaseConfig(
+        List<string> config,
+        string ecoSystem,
+        string directory,
+        string packageTypeLabel,
+        string reviewer
+    )
     {
         this._logger.LogAddingConfigForEcosystem(ecoSystem: ecoSystem, directory: directory);
 
-        config.AddRange([
-            "",
-            $"- package-ecosystem: {ecoSystem}",
-            $"  directory: \"{directory}\"",
-            "  schedule:",
-            "    interval: daily",
-            "    time: \"03:00\"",
-            "    timezone: \"Europe/London\"",
-            "  open-pull-requests-limit: 99",
-            "  assignees:",
-            $"  - {reviewer}",
-            "  commit-message:",
-            "    prefix: \"[Dependencies]\"",
-            "  labels:",
-            $"  - \"{packageTypeLabel}\"",
-            "  - \"dependencies\"",
-            "  - \"Changelog Not Required\""
-        ]);
+        config.AddRange(
+            [
+                "",
+                $"  - package-ecosystem: {ecoSystem}",
+                $"    directory: \"{directory}\"",
+                "    schedule:",
+                "      interval: daily",
+                "      time: \"03:00\"",
+                "      timezone: \"Europe/London\"",
+                "    open-pull-requests-limit: 99",
+                "    assignees:",
+                $"      - {reviewer}",
+                "    commit-message:",
+                "      prefix: \"[Dependencies]\"",
+                "    labels:",
+                $"      - \"{packageTypeLabel}\"",
+                "      - \"dependencies\"",
+                "      - \"Changelog Not Required\"",
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The `dependabot.yml` generator (`DependaBotConfigBuilder`) emitted flush block sequences with no `document-start` marker, which violates this repo's yamllint standard (`document-start: true`, `indent-sequences: true`) enforced by both `.yamllint.yml` and `.github/linters/.yaml-lint.yml`. This made every commit rewrite the file in every downstream repo that uses the tool, failing pre-commit — see `credfeto-dotnet-package-update#584` for the exact yamllint errors this produces.
- Note: issue #175's "Fix required" text asks for the opposite direction (flush, no `---`) — that's a misdiagnosis of which side the linter is on. This PR makes the generator match the linter instead, which is what actually stops the churn.
- Added a full-document exact-output test (`GeneratesYamllintConformingDocument`) — the existing tests were all substring (`Assert.Contains`) checks that pass under either style, so nothing pinned the byte output before this.
- Extracted `AddEcosystemSection` to keep `BuildDependabotConfigAsync` under the method-length analyzer limit after the longer indented string literals pushed CSharpier's formatting over it.

Closes #175

## Test plan

- [x] `dotnet build` (Release) — 0 warnings, 0 errors
- [x] `dotnet test` on `Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests` — 136/136 passed
- [x] `dotnet buildcheck` — no errors
- [x] Piped the generated document through `yamllint -c .yamllint.yml -` — zero findings
- [x] Full repo pre-commit gate (build, all test projects, benchmarks, pack) — all checks passed