### PR TITLE
fix: emit trailing newline in generated dependabot.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- Generate .github/dependabot.yml with a trailing newline so it no longer gets rewritten by pre-commit's end-of-file-fixer on every commit
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
@@ -131,36 +131,37 @@ public sealed class DependaBotConfigBuilderTests : LoggingTestBase, IDisposable
 
         this.Output.WriteLine(result);
 
-        string expected = string.Join(
-            separator: Environment.NewLine,
-            values:
-            [
-                "---",
-                "version: 2",
-                "updates:",
-                "",
-                "  - package-ecosystem: nuget",
-                "    directory: \"/\"",
-                "    schedule:",
-                "      interval: daily",
-                "      time: \"03:00\"",
-                "      timezone: \"Europe/London\"",
-                "    open-pull-requests-limit: 99",
-                "    assignees:",
-                "      - credfeto",
-                "    commit-message:",
-                "      prefix: \"[Dependencies]\"",
-                "    labels:",
-                "      - \"nuget\"",
-                "      - \"dependencies\"",
-                "      - \"Changelog Not Required\"",
-                "    allow:",
-                "      - dependency-type: all",
-                "    ignore:",
-                "      - dependency-name: \"FunFair.Test.Common\"",
-                "      - dependency-name: \"Meziantou.*\"",
-            ]
-        );
+        string expected =
+            string.Join(
+                separator: Environment.NewLine,
+                values:
+                [
+                    "---",
+                    "version: 2",
+                    "updates:",
+                    "",
+                    "  - package-ecosystem: nuget",
+                    "    directory: \"/\"",
+                    "    schedule:",
+                    "      interval: daily",
+                    "      time: \"03:00\"",
+                    "      timezone: \"Europe/London\"",
+                    "    open-pull-requests-limit: 99",
+                    "    assignees:",
+                    "      - credfeto",
+                    "    commit-message:",
+                    "      prefix: \"[Dependencies]\"",
+                    "    labels:",
+                    "      - \"nuget\"",
+                    "      - \"dependencies\"",
+                    "      - \"Changelog Not Required\"",
+                    "    allow:",
+                    "      - dependency-type: all",
+                    "    ignore:",
+                    "      - dependency-name: \"FunFair.Test.Common\"",
+                    "      - dependency-name: \"Meziantou.*\"",
+                ]
+            ) + Environment.NewLine;
 
         Assert.Equal(expected: expected, actual: result, StringComparer.Ordinal);
     }

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/DependaBotConfigBuilder.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Services/DependaBotConfigBuilder.cs
@@ -82,7 +82,7 @@ public sealed class DependaBotConfigBuilder : IDependaBotConfigBuilder
             this.AddEcosystemSection(config: config, ecoSystem: "pip", directory: "/", packageTypeLabel: "python");
         }
 
-        return ValueTask.FromResult(string.Join(separator: Environment.NewLine, values: config));
+        return ValueTask.FromResult(string.Join(separator: Environment.NewLine, values: config) + Environment.NewLine);
     }
 
     private void AddEcosystemSection(List<string> config, string ecoSystem, string directory, string packageTypeLabel)


### PR DESCRIPTION
## Summary

- `BuildDependabotConfigAsync` joined the config lines with `string.Join`, which does not add a trailing separator after the last element, so the generated `.github/dependabot.yml` had no final newline.
- pre-commit's `end-of-file-fixer` hook rewrites that on every commit, producing the same kind of no-op churn as the indentation issue fixed in #175 — see `credfeto-dotnet-package-update#584` and `credfeto/cs-template#972` for the `end-of-file-fixer` symptom on committed copies of this file.
- Appended a trailing newline to the generated document and updated the exact-output test to expect it.

## Test plan

- [x] `dotnet build` (Release) — 0 warnings, 0 errors
- [x] `dotnet test` on `Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests` — 136/136 passed
- [x] `dotnet buildcheck` — no errors
- [x] Piped the generated document through `yamllint -c .yamllint.yml -` — zero findings, including no missing-newline warning
- [x] Full repo pre-commit gate (build, all test projects, benchmarks, pack) — all checks passed