### PR TITLE
fix: compare repo workflows against the template's workflows, not itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Security
 ### Added
 ### Fixed
+- Fixed HasNonStandardGithubActions comparing a repo's workflows directory against itself instead of the template's, so extra workflows now correctly enable the github-actions Dependabot section
 ### Changed
 ### Deprecated
 ### Removed

--- a/src/Credfeto.DotNet.Repo.Tools.Models/RepoContextExtensions.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Models/RepoContextExtensions.cs
@@ -34,11 +34,7 @@ public static class RepoContextExtensions
         string templateActionsPath = Path.Combine(path1: templatePath, path2: ".github", path3: "actions");
         string repoActionsPath = Path.Combine(path1: repoContext.WorkingDirectory, path2: ".github", path3: "actions");
 
-        string templateWorkflowsPath = Path.Combine(
-            path1: repoContext.WorkingDirectory,
-            path2: ".github",
-            path3: "workflows"
-        );
+        string templateWorkflowsPath = Path.Combine(path1: templatePath, path2: ".github", path3: "workflows");
         string repoWorkflowsPath = Path.Combine(
             path1: repoContext.WorkingDirectory,
             path2: ".github",

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Services/DependaBotConfigBuilderTests.cs
@@ -336,6 +336,70 @@ public sealed class DependaBotConfigBuilderTests : LoggingTestBase, IDisposable
         Assert.Contains("- package-ecosystem: github-actions", result, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task WithNonStandardWorkflowGeneratesGithubActionsSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string workflowsDir = Path.Combine(this._tempFolder, ".github", "workflows");
+        Directory.CreateDirectory(workflowsDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(workflowsDir, "custom.yml"),
+            contents: "name: custom workflow",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string templateFolder = Path.Combine(this._tempFolder, "template");
+        Directory.CreateDirectory(templateFolder);
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: templateFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.Contains("- package-ecosystem: github-actions", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WithOnlyTemplateWorkflowDoesNotGenerateGithubActionsSection()
+    {
+        IGitRepository repository = this.CreateRepository();
+        RepoContext repoContext = new(Repository: repository, ChangeLogFileName: "CHANGELOG.md");
+
+        string workflowsDir = Path.Combine(this._tempFolder, ".github", "workflows");
+        Directory.CreateDirectory(workflowsDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(workflowsDir, "standard.yml"),
+            contents: "name: standard workflow",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string templateFolder = Path.Combine(this._tempFolder, "template");
+        string templateWorkflowsDir = Path.Combine(templateFolder, ".github", "workflows");
+        Directory.CreateDirectory(templateWorkflowsDir);
+        await File.WriteAllTextAsync(
+            path: Path.Combine(templateWorkflowsDir, "standard.yml"),
+            contents: "name: standard workflow",
+            cancellationToken: this.CancellationToken()
+        );
+
+        string result = await this._dependaBotConfigBuilder.BuildDependabotConfigAsync(
+            repoContext: repoContext,
+            templateFolder: templateFolder,
+            dotNetFiles: EmptyDotNetFiles(),
+            packages: [],
+            cancellationToken: this.CancellationToken()
+        );
+
+        this.Output.WriteLine(result);
+        Assert.DoesNotContain("- package-ecosystem: github-actions", result, StringComparison.Ordinal);
+    }
+
     private IGitRepository CreateRepository(bool hasSubmodules = false)
     {
         IGitRepository repository = GetSubstitute<IGitRepository>();


### PR DESCRIPTION
## Summary

- `HasNonStandardGithubActions` built both `templateWorkflowsPath` and `repoWorkflowsPath` from `repoContext.WorkingDirectory`, so the workflows half of the check always compared the repo's `.github/workflows` directory against itself. `repoFiles.Except(templateFiles)` was therefore always empty — this half of the check was dead code. Only extra files under `.github/actions` could ever be detected.
- Repos with extra workflows but no extra composite actions (e.g. those built off `funfair-server-template`) never got a `package-ecosystem: github-actions` Dependabot section, so third-party actions pinned in those workflows never received version updates.
- `templateWorkflowsPath` is now built from `templatePath`, matching how `templateActionsPath` is already built a few lines above.
- Added a positive test (extra workflow file with an empty template workflows dir) and a negative test (repo and template share the same workflow file), so a regression back to either "always dead" or an accidental "always true" is caught.

Fixes #225

## Test plan

- [x] `dotnet build` (Release) — 0 warnings, 0 errors
- [x] `dotnet test` on `Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests` — 140/140 passed (new positive + negative tests included)
- [x] `dotnet buildcheck` — no errors
- [x] Full repo pre-commit gate (build, all test projects, benchmarks, pack) — all checks passed