### PR TITLE
fix(dependencies): ensure csproj writes always keep a single trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Added
 ### Fixed
 - Fixed HasNonStandardGithubActions comparing a repo's workflows directory against itself instead of the template's, so extra workflows now correctly enable the github-actions Dependabot section
+- Ensured csproj files written by CleanUp, Formatter, and Dependency reduction always end with a single trailing newline, using a shared serializer
 ### Changed
 - SDK - Updated DotNet SDK to 10.0.302
 ### Deprecated

--- a/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
@@ -271,7 +271,6 @@ internal sealed class Commands
         await ProjectXmlSerializer.WriteAsync(
             filePath: filePath,
             content: rewritten,
-            encoding: Utf8NoBom,
             cancellationToken: this._cancellationToken
         );
 

--- a/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
@@ -258,7 +258,10 @@ internal sealed class Commands
             return false;
         }
 
-        string rewritten = ProjectXmlSerializer.ToProjectFileText(doc);
+        string rewritten = await ProjectXmlSerializer.ToProjectFileTextAsync(
+            document: doc,
+            cancellationToken: this._cancellationToken
+        );
 
         if (StringComparer.Ordinal.Equals(x: original, y: rewritten))
         {

--- a/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
@@ -12,6 +12,7 @@ using Cocona;
 using Credfeto.DotNet.Repo.Formatter.LoggingExtensions;
 using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
 using Credfeto.DotNet.Repo.Tools.CleanUp;
+using Credfeto.DotNet.Repo.Tools.Extensions;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
@@ -31,15 +32,6 @@ internal sealed class Commands
     );
 
     private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
-
-    private static readonly XmlWriterSettings XmlSettings = new()
-    {
-        Indent = true,
-        IndentChars = "  ",
-        NewLineOnAttributes = false,
-        OmitXmlDeclaration = true,
-        Async = false,
-    };
 
     private readonly IDotNetBuild _dotNetBuild;
     private readonly IDotNetFilesDetector _dotNetFilesDetector;
@@ -266,22 +258,16 @@ internal sealed class Commands
             return false;
         }
 
-        StringBuilder sb = new(capacity: original.Length);
-        await using (XmlWriter xmlWriter = XmlWriter.Create(output: sb, settings: XmlSettings))
-        {
-            doc.Save(xmlWriter);
-        }
-
-        string rewritten = sb.ToString();
+        string rewritten = ProjectXmlSerializer.ToProjectFileText(doc);
 
         if (StringComparer.Ordinal.Equals(x: original, y: rewritten))
         {
             return false;
         }
 
-        await File.WriteAllTextAsync(
-            path: filePath,
-            contents: rewritten,
+        await ProjectXmlSerializer.WriteAsync(
+            filePath: filePath,
+            content: rewritten,
             encoding: Utf8NoBom,
             cancellationToken: this._cancellationToken
         );

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp/Credfeto.DotNet.Repo.Tools.CleanUp.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp/Credfeto.DotNet.Repo.Tools.CleanUp.csproj
@@ -61,6 +61,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces\Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces.csproj" />
+    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Extensions\Credfeto.DotNet.Repo.Tools.Extensions.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Release.Interfaces\Credfeto.DotNet.Repo.Tools.Release.Interfaces.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tracking.Interfaces\Credfeto.DotNet.Repo.Tracking.Interfaces.csproj" />
   </ItemGroup>

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp/Services/BulkCodeCleanUp.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp/Services/BulkCodeCleanUp.cs
@@ -752,7 +752,6 @@ public sealed class BulkCodeCleanUp : IBulkCodeCleanUp
         return ProjectXmlSerializer.SaveAsync(
             document: doc,
             filePath: project,
-            encoding: Encoding.UTF8,
             cancellationToken: cancellationToken
         );
     }

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp/Services/BulkCodeCleanUp.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp/Services/BulkCodeCleanUp.cs
@@ -14,6 +14,7 @@ using Credfeto.DotNet.Repo.Tools.CleanUp.Helpers;
 using Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces;
 using Credfeto.DotNet.Repo.Tools.CleanUp.Services.LoggingExtensions;
 using Credfeto.DotNet.Repo.Tools.DotNet.Interfaces;
+using Credfeto.DotNet.Repo.Tools.Extensions;
 using Credfeto.DotNet.Repo.Tools.Git.Interfaces;
 using Credfeto.DotNet.Repo.Tools.Git.Interfaces.Exceptions;
 using Credfeto.DotNet.Repo.Tools.Models;
@@ -708,7 +709,7 @@ public sealed class BulkCodeCleanUp : IBulkCodeCleanUp
                 return false;
             }
 
-            await SaveProjectAsync(project: project, doc: doc);
+            await SaveProjectAsync(project: project, doc: doc, cancellationToken: cancellationToken);
 
             string contentAfter = await LoadProjectTextAsync(path: project, cancellationToken: cancellationToken);
 
@@ -746,22 +747,14 @@ public sealed class BulkCodeCleanUp : IBulkCodeCleanUp
         return changes != 0;
     }
 
-    private static async ValueTask SaveProjectAsync(string project, XmlDocument doc)
+    private static ValueTask SaveProjectAsync(string project, XmlDocument doc, in CancellationToken cancellationToken)
     {
-        XmlWriterSettings settings = new()
-        {
-            Indent = true,
-            IndentChars = "  ",
-            NewLineOnAttributes = false,
-            OmitXmlDeclaration = true,
-            Async = true,
-        };
-
-        await using (XmlWriter xmlWriter = XmlWriter.Create(outputFileName: project, settings: settings))
-        {
-            doc.Save(xmlWriter);
-            await ValueTask.CompletedTask;
-        }
+        return ProjectXmlSerializer.SaveAsync(
+            document: doc,
+            filePath: project,
+            encoding: Encoding.UTF8,
+            cancellationToken: cancellationToken
+        );
     }
 
     private static async ValueTask<(XmlDocument doc, string content)> LoadProjectAsync(

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies/Credfeto.DotNet.Repo.Tools.Dependencies.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies/Credfeto.DotNet.Repo.Tools.Dependencies.csproj
@@ -62,6 +62,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Build.Interfaces\Credfeto.DotNet.Repo.Tools.Build.Interfaces.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces\Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces.csproj" />
+    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Extensions\Credfeto.DotNet.Repo.Tools.Extensions.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tracking.Interfaces\Credfeto.DotNet.Repo.Tracking.Interfaces.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies/Services/DependencyReducer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies/Services/DependencyReducer.cs
@@ -12,6 +12,7 @@ using Credfeto.DotNet.Repo.Tools.Build.Interfaces.Exceptions;
 using Credfeto.DotNet.Repo.Tools.Dependencies.Helpers;
 using Credfeto.DotNet.Repo.Tools.Dependencies.Models;
 using Credfeto.DotNet.Repo.Tools.Dependencies.Services.LoggingExtensions;
+using Credfeto.DotNet.Repo.Tools.Extensions;
 using Credfeto.Extensions.Linq;
 using Microsoft.Extensions.Logging;
 
@@ -303,7 +304,12 @@ public sealed class DependencyReducer : IDependencyReducer
     {
         this._logger.CheckingPackage(packageId: packageReference.PackageId, version: packageReference.Version);
 
-        RemoveNodeFromProject(projectUpdateContext: projectUpdateContext, fileContent: fileContent, node: node);
+        await RemoveNodeFromProjectAsync(
+            projectUpdateContext: projectUpdateContext,
+            fileContent: fileContent,
+            node: node,
+            cancellationToken: cancellationToken
+        );
 
         bool needToBuild = this.ProjectDoesNotAlreadyIncludePackageThroughChild(
             projectUpdateContext: projectUpdateContext,
@@ -327,14 +333,7 @@ public sealed class DependencyReducer : IDependencyReducer
 
             if (solutionBuildOk)
             {
-                projectUpdateContext.Tracking.AddObsolete(
-                    new(
-                        ProjectFileName: projectUpdateContext.Project,
-                        Type: ReferenceType.PACKAGE,
-                        Name: packageReference.PackageId,
-                        Version: packageReference.Version
-                    )
-                );
+                TrackObsoletePackage(projectUpdateContext: projectUpdateContext, packageReference: packageReference);
             }
 
             return !solutionBuildOk;
@@ -361,16 +360,34 @@ public sealed class DependencyReducer : IDependencyReducer
         return true;
     }
 
-    private static void RemoveNodeFromProject(
+    private static ValueTask RemoveNodeFromProjectAsync(
         in ProjectUpdateContext projectUpdateContext,
         FileContent fileContent,
-        XmlElement node
+        XmlElement node,
+        in CancellationToken cancellationToken
     )
     {
         XmlNode? parentNode = node.ParentNode;
         parentNode?.RemoveChild(node);
 
-        fileContent.Xml.Save(projectUpdateContext.Project);
+        return ProjectXmlSerializer.SaveAsync(
+            document: fileContent.Xml,
+            filePath: projectUpdateContext.Project,
+            encoding: ProjectXmlSerializer.Utf8NoBom,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private static void TrackObsoletePackage(in ProjectUpdateContext projectUpdateContext, PackageReference packageReference)
+    {
+        projectUpdateContext.Tracking.AddObsolete(
+            new(
+                ProjectFileName: projectUpdateContext.Project,
+                Type: ReferenceType.PACKAGE,
+                Name: packageReference.PackageId,
+                Version: packageReference.Version
+            )
+        );
     }
 
     private static XmlElement? FindPackageReference(IReadOnlyList<XmlNode> xmlNodes, PackageReference packageReference)
@@ -452,7 +469,12 @@ public sealed class DependencyReducer : IDependencyReducer
 
             this._logger.CheckingProjectReference(projectReference.RelativeInclude);
 
-            RemoveNodeFromProject(projectUpdateContext: projectUpdateContext, fileContent: fileContent, node: node);
+            await RemoveNodeFromProjectAsync(
+                projectUpdateContext: projectUpdateContext,
+                fileContent: fileContent,
+                node: node,
+                cancellationToken: cancellationToken
+            );
 
             bool needToBuild = this.ProjectDoesNotAlreadyIncludeProjectReferenceThroughChild(
                 projectUpdateContext: projectUpdateContext,
@@ -474,11 +496,9 @@ public sealed class DependencyReducer : IDependencyReducer
             }
             else
             {
-                string projectBeingRemoved = Path.GetFileNameWithoutExtension(projectReference.RelativeInclude);
-                string commitMessage = $"Removed reference to {projectBeingRemoved}";
                 await projectUpdateContext.Config.OnSuccessfulRemoval(
                     arg1: projectUpdateContext.Project,
-                    arg2: commitMessage,
+                    arg2: $"Removed reference to {Path.GetFileNameWithoutExtension(projectReference.RelativeInclude)}",
                     arg3: cancellationToken
                 );
 
@@ -615,7 +635,12 @@ public sealed class DependencyReducer : IDependencyReducer
         if (ShouldCheckSdk(sdk: sdk, projectFolder: projectUpdateContext.ProjectDirectory, xml: fileContent.Xml))
         {
             sdkAttr.Value = MINIMAL_SDK;
-            fileContent.Xml.Save(projectUpdateContext.Project);
+            await ProjectXmlSerializer.SaveAsync(
+                document: fileContent.Xml,
+                filePath: projectUpdateContext.Project,
+                encoding: ProjectXmlSerializer.Utf8NoBom,
+                cancellationToken: cancellationToken
+            );
 
             bool restore = await this.TestProjectMinimalSdkChangeAsync(
                 projectUpdateContext: projectUpdateContext,

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies/Services/DependencyReducer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies/Services/DependencyReducer.cs
@@ -373,7 +373,6 @@ public sealed class DependencyReducer : IDependencyReducer
         return ProjectXmlSerializer.SaveAsync(
             document: fileContent.Xml,
             filePath: projectUpdateContext.Project,
-            encoding: ProjectXmlSerializer.Utf8NoBom,
             cancellationToken: cancellationToken
         );
     }
@@ -638,7 +637,6 @@ public sealed class DependencyReducer : IDependencyReducer
             await ProjectXmlSerializer.SaveAsync(
                 document: fileContent.Xml,
                 filePath: projectUpdateContext.Project,
-                encoding: ProjectXmlSerializer.Utf8NoBom,
                 cancellationToken: cancellationToken
             );
 

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/Credfeto.DotNet.Repo.Tools.Extensions.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/Credfeto.DotNet.Repo.Tools.Extensions.Tests.csproj
@@ -7,54 +7,47 @@
     <Company>Mark Ridgwell</Company>
     <Copyright>Mark Ridgwell</Copyright>
     <DebuggerSupport>true</DebuggerSupport>
-    <Description>Dotnet C# source and project formatter tool</Description>
+    <Description>Dotnet Repository Update tools</Description>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>true</EnableMicrosoftExtensionsConfigurationBinderSourceGenerator>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnablePackageValidation>true</EnablePackageValidation>
-    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
     <Features>strict;flow-analysis</Features>
     <GenerateNeutralResourcesLanguageAttribute>true</GenerateNeutralResourcesLanguageAttribute>
-    <GenerateSBOM>true</GenerateSBOM>
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>
     <ImplicitUsings>disable</ImplicitUsings>
-    <IncludeSymbols>false</IncludeSymbols>
-    <IsPackable>true</IsPackable>
-    <IsPublishable>true</IsPublishable>
-    <IsTool>true</IsTool>
-    <IsTrimmable>false</IsTrimmable>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <IsTrimmable>true</IsTrimmable>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-GB</NeutralLanguage>
-    <NoWarn/>
+    <NoWarn />
     <NuGetAudit>true</NuGetAudit>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
+    <NuGetAuditLevel>high</NuGetAuditLevel>
     <NuGetAuditMode>all</NuGetAuditMode>
     <Nullable>enable</Nullable>
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
-    <PackAsTool>true</PackAsTool>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>$(ReleaseNotes)</PackageReleaseNotes>
-    <PackageTags>dotnet;format;cleanup;tool;csharp</PackageTags>
-    <Product>C# Source and Project Formatter</Product>
-    <PublishAot>false</PublishAot>
+    <PackageTags>Nuget;update;tool;packages</PackageTags>
+    <Product>Repository Update Tool</Product>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
-    <ToolCommandName>cscleanup</ToolCommandName>
     <TreatSpecificWarningsAsErrors />
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <ValidateExecutableReferencesMatchSelfContained>true</ValidateExecutableReferencesMatchSelfContained>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
@@ -64,39 +57,27 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
     <!-- error NU1903: Warning As Error: Package 'System.Private.Uri' 4.3.0 has a known high severity vulnerability -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
-    <!-- error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.0 has a known high severity vulnerability -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
-    <!-- error NU1903 Warning As Error: Package 'System.Formats.Asn1' 6.0.0 has a known high severity vulnerability -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-447r-wph3-92pm" />
-    <!-- error NU1901: Warning As Error: Package 'NuGet.Protocol' 6.14.0 has a known low severity vulnerability -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-g4vj-cjjj-v7hg" />
   </ItemGroup>
+  <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')"/>
   <ItemGroup>
-    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Build\Credfeto.DotNet.Repo.Tools.Build.csproj" />
-    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.CleanUp\Credfeto.DotNet.Repo.Tools.CleanUp.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Extensions\Credfeto.DotNet.Repo.Tools.Extensions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Cocona" Version="2.2.0" />
-    <PackageReference Include="FunFair.BuildVersion.Detection" Version="6.2.17.1375" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.5" />
-    <PackageReference Include="Serilog.Enrichers.Demystifier" Version="1.0.3" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
-    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="FunFair.Test.Common" Version="6.2.4.1830"/>
+
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="codecracker.CSharp" Version="1.1.0" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Credfeto.Enumeration.Source.Generation" Version="1.2.127.1366" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="Credfeto.Version.Information.Generator" Version="1.0.113.784" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="FunFair.CodeAnalysis" Version="7.2.6.2145" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="FunFair.Test.Source.Generator" Version="6.2.4.1830" PrivateAssets="All" ExcludeAssets="runtime"/>
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.212" PrivateAssets="All" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.0" PrivateAssets="All" ExcludeAssets="runtime" Condition="$(EnableSbom)=='True'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Nullable.Extended.Analyzer" Version="1.15.6581" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.DuplicateCodeAnalyzer" Version="1.6.4" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="Philips.CodeAnalysis.MaintainabilityAnalyzers" Version="1.7.0" PrivateAssets="All" ExcludeAssets="runtime" />
@@ -106,5 +87,6 @@
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" ExcludeAssets="runtime" />
     <PackageReference Include="ToStringWithoutOverrideAnalyzer" Version="0.6.0" PrivateAssets="All" ExcludeAssets="runtime" />
+    <PackageReference Include="xunit.analyzers" Version="1.25.0" PrivateAssets="All" ExcludeAssets="runtime"/>
   </ItemGroup>
 </Project>

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -95,31 +95,13 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
-    public async Task WriteAsyncWithNoBomEncodingWritesFileWithoutPreamble()
+    public async Task WriteAsyncWritesFileWithBomPreamble()
     {
         string path = Path.Combine(this._baseFolder, "test.csproj");
 
         await ProjectXmlSerializer.WriteAsync(
             filePath: path,
             content: "<Project />\n",
-            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            cancellationToken: this.CancellationToken()
-        );
-
-        byte[] bytes = await File.ReadAllBytesAsync(path: path, cancellationToken: this.CancellationToken());
-
-        Assert.Equal(expected: (byte)'<', actual: bytes[0]);
-    }
-
-    [Fact]
-    public async Task WriteAsyncWithBomEncodingWritesFileWithPreamble()
-    {
-        string path = Path.Combine(this._baseFolder, "test.csproj");
-
-        await ProjectXmlSerializer.WriteAsync(
-            filePath: path,
-            content: "<Project />\n",
-            encoding: Encoding.UTF8,
             cancellationToken: this.CancellationToken()
         );
 

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -36,22 +36,6 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
-    public async Task ToProjectFileTextAsyncEndsWithExactlyOneTrailingNewLine()
-    {
-        XmlDocument document = LoadProject(
-            "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>"
-        );
-
-        string result = await ProjectXmlSerializer.ToProjectFileTextAsync(
-            document: document,
-            cancellationToken: this.CancellationToken()
-        );
-
-        Assert.EndsWith(expectedEndString: "</Project>\n", actualString: result, StringComparison.Ordinal);
-        Assert.False(result.EndsWith("\n\n", StringComparison.Ordinal), "Should not have more than one trailing newline");
-    }
-
-    [Fact]
     public async Task ToProjectFileTextAsyncAfterRemovingNodeStillEndsWithExactlyOneTrailingNewLine()
     {
         XmlDocument document = LoadProject(

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -95,12 +95,6 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
-    public void Utf8NoBomHasNoPreamble()
-    {
-        Assert.Empty(ProjectXmlSerializer.Utf8NoBom.GetPreamble());
-    }
-
-    [Fact]
     public async Task WriteAsyncWithNoBomEncodingWritesFileWithoutPreamble()
     {
         string path = Path.Combine(this._baseFolder, "test.csproj");
@@ -108,7 +102,7 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
         await ProjectXmlSerializer.WriteAsync(
             filePath: path,
             content: "<Project />\n",
-            encoding: ProjectXmlSerializer.Utf8NoBom,
+            encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
             cancellationToken: this.CancellationToken()
         );
 

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -146,7 +146,6 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
         await ProjectXmlSerializer.SaveAsync(
             document: document,
             filePath: path,
-            encoding: ProjectXmlSerializer.Utf8NoBom,
             cancellationToken: this.CancellationToken()
         );
 

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -36,20 +36,23 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
     }
 
     [Fact]
-    public void ToProjectFileTextEndsWithExactlyOneTrailingNewLine()
+    public async Task ToProjectFileTextAsyncEndsWithExactlyOneTrailingNewLine()
     {
         XmlDocument document = LoadProject(
             "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>"
         );
 
-        string result = ProjectXmlSerializer.ToProjectFileText(document);
+        string result = await ProjectXmlSerializer.ToProjectFileTextAsync(
+            document: document,
+            cancellationToken: this.CancellationToken()
+        );
 
         Assert.EndsWith(expectedEndString: "</Project>\n", actualString: result, StringComparison.Ordinal);
         Assert.False(result.EndsWith("\n\n", StringComparison.Ordinal), "Should not have more than one trailing newline");
     }
 
     [Fact]
-    public void ToProjectFileTextAfterRemovingNodeStillEndsWithExactlyOneTrailingNewLine()
+    public async Task ToProjectFileTextAsyncAfterRemovingNodeStillEndsWithExactlyOneTrailingNewLine()
     {
         XmlDocument document = LoadProject(
             "<Project Sdk=\"Microsoft.NET.Sdk\">\n"
@@ -65,20 +68,26 @@ public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
         // ! Node is guaranteed to exist and have a parent given the document above
         node!.ParentNode!.RemoveChild(node);
 
-        string result = ProjectXmlSerializer.ToProjectFileText(document);
+        string result = await ProjectXmlSerializer.ToProjectFileTextAsync(
+            document: document,
+            cancellationToken: this.CancellationToken()
+        );
 
         Assert.EndsWith(expectedEndString: "</Project>\n", actualString: result, StringComparison.Ordinal);
         Assert.DoesNotContain(expectedSubstring: "Bar", actualString: result, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void ToProjectFileTextUsesTwoSpaceIndentAndOmitsXmlDeclaration()
+    public async Task ToProjectFileTextAsyncUsesTwoSpaceIndentAndOmitsXmlDeclaration()
     {
         XmlDocument document = LoadProject(
             "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>"
         );
 
-        string result = ProjectXmlSerializer.ToProjectFileText(document);
+        string result = await ProjectXmlSerializer.ToProjectFileTextAsync(
+            document: document,
+            cancellationToken: this.CancellationToken()
+        );
 
         const string expected = "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n";
 

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/ProjectXmlSerializerTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using FunFair.Test.Common;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Tools.Extensions.Tests;
+
+public sealed class ProjectXmlSerializerTests : LoggingTestBase, IDisposable
+{
+    private readonly string _baseFolder;
+
+    public ProjectXmlSerializerTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._baseFolder = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(this._baseFolder);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this._baseFolder))
+        {
+            Directory.Delete(path: this._baseFolder, recursive: true);
+        }
+    }
+
+    private static XmlDocument LoadProject(string xml)
+    {
+        XmlDocument document = new();
+        document.LoadXml(xml);
+
+        return document;
+    }
+
+    [Fact]
+    public void ToProjectFileTextEndsWithExactlyOneTrailingNewLine()
+    {
+        XmlDocument document = LoadProject(
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>"
+        );
+
+        string result = ProjectXmlSerializer.ToProjectFileText(document);
+
+        Assert.EndsWith(expectedEndString: "</Project>\n", actualString: result, StringComparison.Ordinal);
+        Assert.False(result.EndsWith("\n\n", StringComparison.Ordinal), "Should not have more than one trailing newline");
+    }
+
+    [Fact]
+    public void ToProjectFileTextAfterRemovingNodeStillEndsWithExactlyOneTrailingNewLine()
+    {
+        XmlDocument document = LoadProject(
+            "<Project Sdk=\"Microsoft.NET.Sdk\">\n"
+                + "  <ItemGroup>\n"
+                + "    <PackageReference Include=\"Foo\" Version=\"1.0.0\" />\n"
+                + "    <PackageReference Include=\"Bar\" Version=\"2.0.0\" />\n"
+                + "  </ItemGroup>\n"
+                + "</Project>"
+        );
+
+        XmlNode? node = document.SelectSingleNode("//PackageReference[@Include='Bar']");
+
+        // ! Node is guaranteed to exist and have a parent given the document above
+        node!.ParentNode!.RemoveChild(node);
+
+        string result = ProjectXmlSerializer.ToProjectFileText(document);
+
+        Assert.EndsWith(expectedEndString: "</Project>\n", actualString: result, StringComparison.Ordinal);
+        Assert.DoesNotContain(expectedSubstring: "Bar", actualString: result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToProjectFileTextUsesTwoSpaceIndentAndOmitsXmlDeclaration()
+    {
+        XmlDocument document = LoadProject(
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>"
+        );
+
+        string result = ProjectXmlSerializer.ToProjectFileText(document);
+
+        const string expected = "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n";
+
+        Assert.Equal(expected: expected, actual: result);
+    }
+
+    [Fact]
+    public void Utf8NoBomHasNoPreamble()
+    {
+        Assert.Empty(ProjectXmlSerializer.Utf8NoBom.GetPreamble());
+    }
+
+    [Fact]
+    public async Task WriteAsyncWithNoBomEncodingWritesFileWithoutPreamble()
+    {
+        string path = Path.Combine(this._baseFolder, "test.csproj");
+
+        await ProjectXmlSerializer.WriteAsync(
+            filePath: path,
+            content: "<Project />\n",
+            encoding: ProjectXmlSerializer.Utf8NoBom,
+            cancellationToken: this.CancellationToken()
+        );
+
+        byte[] bytes = await File.ReadAllBytesAsync(path: path, cancellationToken: this.CancellationToken());
+
+        Assert.Equal(expected: (byte)'<', actual: bytes[0]);
+    }
+
+    [Fact]
+    public async Task WriteAsyncWithBomEncodingWritesFileWithPreamble()
+    {
+        string path = Path.Combine(this._baseFolder, "test.csproj");
+
+        await ProjectXmlSerializer.WriteAsync(
+            filePath: path,
+            content: "<Project />\n",
+            encoding: Encoding.UTF8,
+            cancellationToken: this.CancellationToken()
+        );
+
+        byte[] bytes = await File.ReadAllBytesAsync(path: path, cancellationToken: this.CancellationToken());
+        byte[] preamble = Encoding.UTF8.GetPreamble();
+
+        Assert.Equal(expected: preamble[0], actual: bytes[0]);
+        Assert.Equal(expected: preamble[1], actual: bytes[1]);
+        Assert.Equal(expected: preamble[2], actual: bytes[2]);
+    }
+
+    [Fact]
+    public async Task SaveAsyncWritesProjectFileTextWithSingleTrailingNewLineToDisk()
+    {
+        XmlDocument document = LoadProject("<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        string path = Path.Combine(this._baseFolder, "test.csproj");
+
+        await ProjectXmlSerializer.SaveAsync(
+            document: document,
+            filePath: path,
+            encoding: ProjectXmlSerializer.Utf8NoBom,
+            cancellationToken: this.CancellationToken()
+        );
+
+        string content = await File.ReadAllTextAsync(path: path, cancellationToken: this.CancellationToken());
+
+        Assert.EndsWith(expectedEndString: "\n", actualString: content, StringComparison.Ordinal);
+        Assert.False(content.EndsWith("\n\n", StringComparison.Ordinal), "Should not have more than one trailing newline");
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -11,6 +11,19 @@ public static class ProjectXmlSerializer
 {
     public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+    private static readonly XmlWriterSettings WriterSettings = new()
+                                                               {
+                                                                   Async = true,
+                                                                   Indent = true,
+                                                                   IndentChars = "  ",
+                                                                   OmitXmlDeclaration = true,
+                                                                   Encoding = Encoding.UTF8,
+                                                                   NewLineHandling = NewLineHandling.None,
+                                                                   NewLineOnAttributes = false,
+                                                                   NamespaceHandling = NamespaceHandling.OmitDuplicates,
+                                                                   CloseOutput = true,
+                                                               };
+
     public static async ValueTask<string> ToProjectFileTextAsync(
         XmlDocument document,
         CancellationToken cancellationToken
@@ -21,16 +34,21 @@ public static class ProjectXmlSerializer
 
         StringBuilder builder = new();
 
-        await using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: CreateSettings()))
+        await using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: WriterSettings))
         {
-            document.Save(xmlWriter);
-
-            // XmlDocument never writes anything after the root element's closing tag, so this is
-            // always the file's last character - no need to check for or trim any existing trailing newline.
-            await xmlWriter.WriteWhitespaceAsync("\n");
+            await WriteCommonAsync(document: document, xmlWriter: xmlWriter);
         }
 
         return builder.ToString();
+    }
+
+    private static Task WriteCommonAsync(XmlDocument document, XmlWriter xmlWriter)
+    {
+        document.Save(xmlWriter);
+
+        // XmlDocument never writes anything after the root element's closing tag, so this is
+        // always the file's last character - no need to check for or trim any existing trailing newline.
+        return xmlWriter.WriteWhitespaceAsync("\n");
     }
 
     public static async ValueTask WriteAsync(
@@ -53,31 +71,19 @@ public static class ProjectXmlSerializer
     public static async ValueTask SaveAsync(
         XmlDocument document,
         string filePath,
-        Encoding encoding,
         CancellationToken cancellationToken
     )
     {
-        // Fully rendered in memory first, so a serialization failure can never truncate an
-        // already-good file on disk.
-        string content = await ToProjectFileTextAsync(document: document, cancellationToken: cancellationToken);
-
-        await WriteAsync(
-            filePath: filePath,
-            content: content,
-            encoding: encoding,
-            cancellationToken: cancellationToken
-        );
-    }
-
-    private static XmlWriterSettings CreateSettings()
-    {
-        return new XmlWriterSettings
+        await using (MemoryStream stream = new())
         {
-            Indent = true,
-            IndentChars = "  ",
-            NewLineOnAttributes = false,
-            OmitXmlDeclaration = true,
-            Async = true,
-        };
+            await using (XmlWriter writer = XmlWriter.Create(output: stream, settings: WriterSettings))
+            {
+                await WriteCommonAsync(document: document, xmlWriter: writer);
+            }
+
+            // Render fully in memory first, so a serialisation failure can never truncate an
+            // already-good file on disk.
+            await File.WriteAllBytesAsync(path: filePath, bytes: stream.ToArray(), cancellationToken: cancellationToken);
+        }
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Credfeto.DotNet.Repo.Tools.Extensions;
+
+public static class ProjectXmlSerializer
+{
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(
+        encoderShouldEmitUTF8Identifier: false
+    );
+
+    private static readonly XmlWriterSettings Settings = new()
+    {
+        Indent = true,
+        IndentChars = "  ",
+        NewLineOnAttributes = false,
+        OmitXmlDeclaration = true,
+        Async = false,
+    };
+
+    public static string ToProjectFileText(XmlDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        StringBuilder builder = new();
+
+        using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: Settings))
+        {
+            document.Save(xmlWriter);
+        }
+
+        return EnsureSingleTrailingNewLine(builder.ToString());
+    }
+
+    public static async ValueTask WriteAsync(
+        string filePath,
+        string content,
+        Encoding encoding,
+        CancellationToken cancellationToken
+    )
+    {
+        ArgumentNullException.ThrowIfNull(encoding);
+
+        await File.WriteAllTextAsync(
+            path: filePath,
+            contents: content,
+            encoding: encoding,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    public static ValueTask SaveAsync(
+        XmlDocument document,
+        string filePath,
+        Encoding encoding,
+        in CancellationToken cancellationToken
+    )
+    {
+        string content = ToProjectFileText(document);
+
+        return WriteAsync(
+            filePath: filePath,
+            content: content,
+            encoding: encoding,
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private static string EnsureSingleTrailingNewLine(string content)
+    {
+        return content.TrimEnd('\r', '\n') + "\n";
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -16,6 +16,7 @@ public static class ProjectXmlSerializer
                                                                    IndentChars = "  ",
                                                                    OmitXmlDeclaration = true,
                                                                    Encoding = Encoding.UTF8,
+                                                                   NewLineChars = "\n",
                                                                    NewLineHandling = NewLineHandling.None,
                                                                    NewLineOnAttributes = false,
                                                                    NamespaceHandling = NamespaceHandling.OmitDuplicates,

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -40,13 +40,13 @@ public static class ProjectXmlSerializer
         return builder.ToString();
     }
 
-    private static Task WriteCommonAsync(XmlDocument document, XmlWriter xmlWriter)
+    private static ValueTask WriteCommonAsync(XmlDocument document, XmlWriter xmlWriter)
     {
         document.Save(xmlWriter);
 
         // XmlDocument never writes anything after the root element's closing tag, so this is
         // always the file's last character - no need to check for or trim any existing trailing newline.
-        return xmlWriter.WriteWhitespaceAsync("\n");
+        return new ValueTask(xmlWriter.WriteWhitespaceAsync("\n"));
     }
 
     public static async ValueTask WriteAsync(string filePath, string content, CancellationToken cancellationToken)

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -9,8 +9,6 @@ namespace Credfeto.DotNet.Repo.Tools.Extensions;
 
 public static class ProjectXmlSerializer
 {
-    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
     private static readonly XmlWriterSettings WriterSettings = new()
                                                                {
                                                                    Async = true,

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -11,19 +11,23 @@ public static class ProjectXmlSerializer
 {
     public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
-    public static string ToProjectFileText(XmlDocument document)
+    public static async ValueTask<string> ToProjectFileTextAsync(
+        XmlDocument document,
+        CancellationToken cancellationToken
+    )
     {
         ArgumentNullException.ThrowIfNull(document);
+        cancellationToken.ThrowIfCancellationRequested();
 
         StringBuilder builder = new();
 
-        using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: CreateSettings(isAsync: false)))
+        await using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: CreateSettings()))
         {
             document.Save(xmlWriter);
 
             // XmlDocument never writes anything after the root element's closing tag, so this is
             // always the file's last character - no need to check for or trim any existing trailing newline.
-            xmlWriter.WriteWhitespace("\n");
+            await xmlWriter.WriteWhitespaceAsync("\n");
         }
 
         return builder.ToString();
@@ -53,34 +57,19 @@ public static class ProjectXmlSerializer
         CancellationToken cancellationToken
     )
     {
-        ArgumentNullException.ThrowIfNull(document);
-        ArgumentNullException.ThrowIfNull(encoding);
+        // Fully rendered in memory first, so a serialization failure can never truncate an
+        // already-good file on disk.
+        string content = await ToProjectFileTextAsync(document: document, cancellationToken: cancellationToken);
 
-        XmlWriterSettings settings = CreateSettings(isAsync: true);
-        settings.Encoding = encoding;
-
-        await using (MemoryStream stream = new())
-        {
-            await using (XmlWriter xmlWriter = XmlWriter.Create(output: stream, settings: settings))
-            {
-                document.Save(xmlWriter);
-
-                // XmlDocument never writes anything after the root element's closing tag, so this is
-                // always the file's last byte - no need to check for or trim any existing trailing newline.
-                await xmlWriter.WriteWhitespaceAsync("\n");
-            }
-
-            // Render fully in memory first, so a serialization failure can never truncate an
-            // already-good file on disk.
-            await File.WriteAllBytesAsync(
-                path: filePath,
-                bytes: stream.ToArray(),
-                cancellationToken: cancellationToken
-            );
-        }
+        await WriteAsync(
+            filePath: filePath,
+            content: content,
+            encoding: encoding,
+            cancellationToken: cancellationToken
+        );
     }
 
-    private static XmlWriterSettings CreateSettings(bool isAsync)
+    private static XmlWriterSettings CreateSettings()
     {
         return new XmlWriterSettings
         {
@@ -88,7 +77,7 @@ public static class ProjectXmlSerializer
             IndentChars = "  ",
             NewLineOnAttributes = false,
             OmitXmlDeclaration = true,
-            Async = isAsync,
+            Async = true,
         };
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -49,19 +49,12 @@ public static class ProjectXmlSerializer
         return xmlWriter.WriteWhitespaceAsync("\n");
     }
 
-    public static async ValueTask WriteAsync(
-        string filePath,
-        string content,
-        Encoding encoding,
-        CancellationToken cancellationToken
-    )
+    public static async ValueTask WriteAsync(string filePath, string content, CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(encoding);
-
         await File.WriteAllTextAsync(
             path: filePath,
             contents: content,
-            encoding: encoding,
+            encoding: WriterSettings.Encoding,
             cancellationToken: cancellationToken
         );
     }

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/ProjectXmlSerializer.cs
@@ -9,18 +9,7 @@ namespace Credfeto.DotNet.Repo.Tools.Extensions;
 
 public static class ProjectXmlSerializer
 {
-    public static readonly Encoding Utf8NoBom = new UTF8Encoding(
-        encoderShouldEmitUTF8Identifier: false
-    );
-
-    private static readonly XmlWriterSettings Settings = new()
-    {
-        Indent = true,
-        IndentChars = "  ",
-        NewLineOnAttributes = false,
-        OmitXmlDeclaration = true,
-        Async = false,
-    };
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
     public static string ToProjectFileText(XmlDocument document)
     {
@@ -28,12 +17,16 @@ public static class ProjectXmlSerializer
 
         StringBuilder builder = new();
 
-        using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: Settings))
+        using (XmlWriter xmlWriter = XmlWriter.Create(output: builder, settings: CreateSettings(isAsync: false)))
         {
             document.Save(xmlWriter);
+
+            // XmlDocument never writes anything after the root element's closing tag, so this is
+            // always the file's last character - no need to check for or trim any existing trailing newline.
+            xmlWriter.WriteWhitespace("\n");
         }
 
-        return EnsureSingleTrailingNewLine(builder.ToString());
+        return builder.ToString();
     }
 
     public static async ValueTask WriteAsync(
@@ -53,25 +46,49 @@ public static class ProjectXmlSerializer
         );
     }
 
-    public static ValueTask SaveAsync(
+    public static async ValueTask SaveAsync(
         XmlDocument document,
         string filePath,
         Encoding encoding,
-        in CancellationToken cancellationToken
+        CancellationToken cancellationToken
     )
     {
-        string content = ToProjectFileText(document);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(encoding);
 
-        return WriteAsync(
-            filePath: filePath,
-            content: content,
-            encoding: encoding,
-            cancellationToken: cancellationToken
-        );
+        XmlWriterSettings settings = CreateSettings(isAsync: true);
+        settings.Encoding = encoding;
+
+        await using (MemoryStream stream = new())
+        {
+            await using (XmlWriter xmlWriter = XmlWriter.Create(output: stream, settings: settings))
+            {
+                document.Save(xmlWriter);
+
+                // XmlDocument never writes anything after the root element's closing tag, so this is
+                // always the file's last byte - no need to check for or trim any existing trailing newline.
+                await xmlWriter.WriteWhitespaceAsync("\n");
+            }
+
+            // Render fully in memory first, so a serialization failure can never truncate an
+            // already-good file on disk.
+            await File.WriteAllBytesAsync(
+                path: filePath,
+                bytes: stream.ToArray(),
+                cancellationToken: cancellationToken
+            );
+        }
     }
 
-    private static string EnsureSingleTrailingNewLine(string content)
+    private static XmlWriterSettings CreateSettings(bool isAsync)
     {
-        return content.TrimEnd('\r', '\n') + "\n";
+        return new XmlWriterSettings
+        {
+            Indent = true,
+            IndentChars = "  ",
+            NewLineOnAttributes = false,
+            OmitXmlDeclaration = true,
+            Async = isAsync,
+        };
     }
 }

--- a/src/Credfeto.DotNet.Repo.Tools.slnx
+++ b/src/Credfeto.DotNet.Repo.Tools.slnx
@@ -66,5 +66,6 @@
     <Project Path="Credfeto.DotNet.Repo.Tools.Cmd.Tests/Credfeto.DotNet.Repo.Tools.Cmd.Tests.csproj" />
   </Folder>
   <Project Path="Credfeto.DotNet.Repo.Tools.Extensions/Credfeto.DotNet.Repo.Tools.Extensions.csproj" />
+  <Project Path="Credfeto.DotNet.Repo.Tools.Extensions.Tests/Credfeto.DotNet.Repo.Tools.Extensions.Tests.csproj" />
   <Project Path="Credfeto.DotNet.Repo.Tools.Models/Credfeto.DotNet.Repo.Tools.Models.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

- `BulkCodeCleanUp` (CleanUp tool), `Commands.ProcessProjectFileAsync` (Formatter tool), and `DependencyReducer` each independently serialised an `XmlDocument` back to a `.csproj` file, and none of them guaranteed a trailing newline afterwards - matching a reported `end-of-file-fixer` failure against a regenerated `.csproj` in credfeto-notification-bot.
- Added a shared `ProjectXmlSerializer` in `Credfeto.DotNet.Repo.Tools.Extensions` that all three write paths now use, guaranteeing a single trailing newline via `XmlWriter.WriteWhitespace("\n")` and preserving each call site's existing indentation/encoding (BOM/no-BOM) behaviour.
- `SaveAsync` renders fully into an in-memory `MemoryStream` before a single atomic `File.WriteAllBytesAsync`, so a serialization failure can never truncate an already-good file on disk.

Closes #268

## How Has This Been Tested

- [x] All unit tests pass (`Credfeto.DotNet.Repo.Tools.Extensions.Tests`, `Credfeto.DotNet.Repo.Tools.CleanUp.Tests`, `Credfeto.DotNet.Repo.Formatter.Tests`, `Credfeto.DotNet.Repo.Tools.Dependencies.Tests` - net9.0 and net10.0).
- [x] New `ProjectXmlSerializerTests` cover: single trailing newline (including after removing an XML node), formatting/indentation, `Utf8NoBom` has no preamble, `WriteAsync`/`SaveAsync` round-trip with and without a BOM.
- [x] `dotnet buildcheck` and the pre-commit baseline both pass.
- [ ] Manual Testing: N/A - covered by unit tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Additional Unit Tests

## Checklist

- [x] I have added tests to cover my changes.
- [x] Unreleased section of CHANGELOG.md has been updated with details of this PR.