### PR TITLE
fix: drop net9.0, target net10.0 only across all projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Ensured csproj files written by CleanUp, Formatter, and Dependency reduction always end with a single trailing newline, using a shared serializer
 ### Changed
 - SDK - Updated DotNet SDK to 10.0.302
+- Dropped support for net9.0; all projects now target net10.0 only
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/src/Credfeto.DotNet.Repo.Formatter.Tests/Credfeto.DotNet.Repo.Formatter.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Formatter.Tests/Credfeto.DotNet.Repo.Formatter.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Formatter/Credfeto.DotNet.Repo.Formatter.csproj
+++ b/src/Credfeto.DotNet.Repo.Formatter/Credfeto.DotNet.Repo.Formatter.csproj
@@ -47,7 +47,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>cscleanup</ToolCommandName>

--- a/src/Credfeto.DotNet.Repo.Tools.Build.Interfaces/Credfeto.DotNet.Repo.Tools.Build.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Build.Interfaces/Credfeto.DotNet.Repo.Tools.Build.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Build.Tests/Credfeto.DotNet.Repo.Tools.Build.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Build.Tests/Credfeto.DotNet.Repo.Tools.Build.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Build/Credfeto.DotNet.Repo.Tools.Build.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Build/Credfeto.DotNet.Repo.Tools.Build.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp.Benchmarks.Tests/Credfeto.DotNet.Repo.Tools.CleanUp.Benchmarks.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp.Benchmarks.Tests/Credfeto.DotNet.Repo.Tools.CleanUp.Benchmarks.Tests.csproj
@@ -40,7 +40,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces/Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces/Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp.Tests/Credfeto.DotNet.Repo.Tools.CleanUp.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp.Tests/Credfeto.DotNet.Repo.Tools.CleanUp.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.CleanUp/Credfeto.DotNet.Repo.Tools.CleanUp.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.CleanUp/Credfeto.DotNet.Repo.Tools.CleanUp.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Cmd.Tests/Credfeto.DotNet.Repo.Tools.Cmd.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Cmd.Tests/Credfeto.DotNet.Repo.Tools.Cmd.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Cmd/Credfeto.DotNet.Repo.Tools.Cmd.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Cmd/Credfeto.DotNet.Repo.Tools.Cmd.csproj
@@ -47,7 +47,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>win-x64;win-arm64;osx-x64;osx-arm64;linux-x64;linux-arm64</RuntimeIdentifiers>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <ToolCommandName>updaterepo</ToolCommandName>

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces/Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces/Credfeto.DotNet.Repo.Tools.Dependencies.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies.Tests/Credfeto.DotNet.Repo.Tools.Dependencies.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies.Tests/Credfeto.DotNet.Repo.Tools.Dependencies.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Dependencies/Credfeto.DotNet.Repo.Tools.Dependencies.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Dependencies/Credfeto.DotNet.Repo.Tools.Dependencies.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Interfaces/Credfeto.DotNet.Repo.Tools.DotNet.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Interfaces/Credfeto.DotNet.Repo.Tools.DotNet.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Credfeto.DotNet.Repo.Tools.DotNet.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet.Tests/Credfeto.DotNet.Repo.Tools.DotNet.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.DotNet/Credfeto.DotNet.Repo.Tools.DotNet.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.DotNet/Credfeto.DotNet.Repo.Tools.DotNet.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/Credfeto.DotNet.Repo.Tools.Extensions.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions.Tests/Credfeto.DotNet.Repo.Tools.Extensions.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Extensions/Credfeto.DotNet.Repo.Tools.Extensions.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Extensions/Credfeto.DotNet.Repo.Tools.Extensions.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Git.Integration.Tests/Credfeto.DotNet.Repo.Tools.Git.Integration.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Git.Integration.Tests/Credfeto.DotNet.Repo.Tools.Git.Integration.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Git.Interfaces/Credfeto.DotNet.Repo.Tools.Git.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Git.Interfaces/Credfeto.DotNet.Repo.Tools.Git.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Git.Tests/Credfeto.DotNet.Repo.Tools.Git.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Git.Tests/Credfeto.DotNet.Repo.Tools.Git.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Git/Credfeto.DotNet.Repo.Tools.Git.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Git/Credfeto.DotNet.Repo.Tools.Git.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Models/Credfeto.DotNet.Repo.Tools.Models.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Models/Credfeto.DotNet.Repo.Tools.Models.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Interfaces/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Interfaces/Credfeto.DotNet.Repo.Tools.Packages.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Credfeto.DotNet.Repo.Tools.Packages.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages.Tests/Credfeto.DotNet.Repo.Tools.Packages.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Packages/Credfeto.DotNet.Repo.Tools.Packages.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Packages/Credfeto.DotNet.Repo.Tools.Packages.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Release.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.Release.Interfaces.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Release.Interfaces.Tests/Credfeto.DotNet.Repo.Tools.Release.Interfaces.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Release.Interfaces/Credfeto.DotNet.Repo.Tools.Release.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Release.Interfaces/Credfeto.DotNet.Repo.Tools.Release.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.Release.Tests/Credfeto.DotNet.Repo.Tools.Release.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Release.Tests/Credfeto.DotNet.Repo.Tools.Release.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.Release/Credfeto.DotNet.Repo.Tools.Release.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.Release/Credfeto.DotNet.Repo.Tools.Release.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests/Credfeto.DotNet.Repo.Tools.TemplateUpdate.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Credfeto.DotNet.Repo.Tools.TemplateUpdate.csproj
+++ b/src/Credfeto.DotNet.Repo.Tools.TemplateUpdate/Credfeto.DotNet.Repo.Tools.TemplateUpdate.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tracking.Interfaces/Credfeto.DotNet.Repo.Tracking.Interfaces.csproj
+++ b/src/Credfeto.DotNet.Repo.Tracking.Interfaces/Credfeto.DotNet.Repo.Tracking.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.DotNet.Repo.Tracking.Tests/Credfeto.DotNet.Repo.Tracking.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Tracking.Tests/Credfeto.DotNet.Repo.Tracking.Tests.csproj
@@ -39,7 +39,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.DotNet.Repo.Tracking/Credfeto.DotNet.Repo.Tracking.csproj
+++ b/src/Credfeto.DotNet.Repo.Tracking/Credfeto.DotNet.Repo.Tracking.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-dotnet-repo-tools</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary

- Replaces `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>` with a single `<TargetFramework>net10.0</TargetFramework>` in all 38 affected `.csproj` files under `src/`.
- No net9.0-specific dead code was found to clean up: no `Condition="...net9.0..."`, no non-`_OR_GREATER` `#if NET9_0` guards, and `global.json`/CI workflow files were already net10.0-only.

Closes #267

## Test plan

- [x] `pre-commit --all-files` baseline check passed on `main` before starting work
- [x] Full `dotnet buildcheck` passed with no errors
- [x] Full `dotnet build` (Release) succeeded, net10.0 only
- [x] Full `dotnet test` suite passed
- [x] Publish/pack steps succeeded for all publishable projects
