### PR TITLE
chore: start work on unit tests for Credfeto.DotNet.Repo.Formatter (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ## [Unreleased]
 ### Security
 ### Added
+- Unit tests for 100% code coverage of Credfeto.DotNet.Repo.Formatter
 ### Fixed
 - Fixed HasNonStandardGithubActions comparing a repo's workflows directory against itself instead of the template's, so extra workflows now correctly enable the github-actions Dependabot section
 - Ensured csproj files written by CleanUp, Formatter, and Dependency reduction always end with a single trailing newline, using a shared serializer

--- a/src/Credfeto.DotNet.Repo.Formatter.Tests/CommandsTests.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter.Tests/CommandsTests.cs
@@ -1,0 +1,376 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using Credfeto.DotNet.Repo.Formatter.Constants;
+using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
+using Credfeto.DotNet.Repo.Tools.CleanUp;
+using Credfeto.DotNet.Repo.Tools.Extensions;
+using FunFair.Test.Common;
+using NSubstitute;
+using Xunit;
+
+namespace Credfeto.DotNet.Repo.Formatter.Tests;
+
+public sealed class CommandsTests : LoggingFolderCleanupTestBase
+{
+    private readonly Commands _commands;
+    private readonly IDotNetBuild _dotNetBuild;
+    private readonly IDotNetFilesDetector _dotNetFilesDetector;
+    private readonly IProjectXmlRewriter _projectXmlRewriter;
+    private readonly IResharperSuppressionToSuppressMessage _resharperSuppressionToSuppressMessage;
+    private readonly ISourceFileReformatter _sourceFileReformatter;
+    private readonly ISourceFileSuppressionRemover _sourceFileSuppressionRemover;
+    private readonly IXmlDocCommentRemover _xmlDocCommentRemover;
+
+    public CommandsTests(ITestOutputHelper output)
+        : base(output)
+    {
+        this._projectXmlRewriter = GetSubstitute<IProjectXmlRewriter>();
+        this._sourceFileReformatter = GetSubstitute<ISourceFileReformatter>();
+        this._xmlDocCommentRemover = GetSubstitute<IXmlDocCommentRemover>();
+        this._resharperSuppressionToSuppressMessage = GetSubstitute<IResharperSuppressionToSuppressMessage>();
+        this._sourceFileSuppressionRemover = GetSubstitute<ISourceFileSuppressionRemover>();
+        this._dotNetBuild = GetSubstitute<IDotNetBuild>();
+        this._dotNetFilesDetector = GetSubstitute<IDotNetFilesDetector>();
+
+        this.SetupPassThroughCsCleaners();
+
+        this._commands = new Commands(
+            projectXmlRewriter: this._projectXmlRewriter,
+            sourceFileReformatter: this._sourceFileReformatter,
+            xmlDocCommentRemover: this._xmlDocCommentRemover,
+            resharperSuppressionToSuppressMessage: this._resharperSuppressionToSuppressMessage,
+            sourceFileSuppressionRemover: this._sourceFileSuppressionRemover,
+            dotNetBuild: this._dotNetBuild,
+            dotNetFilesDetector: this._dotNetFilesDetector,
+            logger: this.GetTypedLogger<Commands>()
+        );
+    }
+
+    [SuppressMessage(
+        category: "Microsoft.Reliability",
+        checkId: "CA2012: Use ValueTasks correctly",
+        Justification = "NSubstitute mock setup requires calling async methods without awaiting"
+    )]
+    private void SetupPassThroughCsCleaners()
+    {
+        this._resharperSuppressionToSuppressMessage.Replace(Arg.Any<string>()).Returns(x => x.ArgAt<string>(0));
+        this._xmlDocCommentRemover.RemoveXmlDocComments(Arg.Any<string>()).Returns(x => x.ArgAt<string>(0));
+        this._sourceFileReformatter.ReformatAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(x => ValueTask.FromResult(x.ArgAt<string>(1)));
+        this._sourceFileSuppressionRemover.RemoveSuppressionsAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<BuildContext>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(x => ValueTask.FromResult(x.ArgAt<string>(1)));
+    }
+
+    private void SetupBuildRoot(string buildRoot, IReadOnlyList<string> projects)
+    {
+        this._dotNetFilesDetector.FindAsync(baseFolder: buildRoot, cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(new DotNetFiles(SourceDirectory: buildRoot, Solutions: [], Projects: projects));
+        this._dotNetBuild.LoadBuildSettingsAsync(
+                projects: Arg.Any<IReadOnlyList<string>>(),
+                cancellationToken: Arg.Any<CancellationToken>()
+            )
+            .Returns(new BuildSettings(PublishableProjects: [], PackableProjects: [], Framework: null));
+    }
+
+    private async Task<string> CreateFileAsync(string relativePath, string content)
+    {
+        string fullPath = Path.Combine(path1: this.TempFolder, path2: relativePath);
+        string? directory = Path.GetDirectoryName(fullPath);
+
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(path: fullPath, contents: content, cancellationToken: this.CancellationToken());
+
+        return fullPath;
+    }
+
+    private Task<string> ReadFileAsync(string path)
+    {
+        return File.ReadAllTextAsync(path: path, cancellationToken: this.CancellationToken());
+    }
+
+    private ValueTask<string> ReceivedRemoveSuppressionsAsync(int times)
+    {
+        return this
+            ._sourceFileSuppressionRemover.ReceivedWithAnyArgs(times)
+            .RemoveSuppressionsAsync(string.Empty, string.Empty, default, default);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("   ")]
+    public async Task CleanupAsyncReturnsErrorWhenRemoveSuppressionsWithoutBuildRootAsync(string? buildRoot)
+    {
+        int result = await this._commands.CleanupAsync(
+            inputs: ["file.cs"],
+            removeSuppressions: true,
+            buildRoot: buildRoot
+        );
+
+        Assert.Equal(expected: ExitCodes.Error, actual: result);
+        await this._dotNetFilesDetector.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncReturnsErrorWhenBuildRootDoesNotExistAsync()
+    {
+        string missingBuildRoot = Path.Combine(path1: this.TempFolder, path2: "does-not-exist");
+
+        int result = await this._commands.CleanupAsync(
+            inputs: ["file.cs"],
+            removeSuppressions: false,
+            buildRoot: missingBuildRoot
+        );
+
+        Assert.Equal(expected: ExitCodes.Error, actual: result);
+        await this._dotNetFilesDetector.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncReturnsErrorWhenNoInputFilesAsync()
+    {
+        int result = await this._commands.CleanupAsync(inputs: []);
+
+        Assert.Equal(expected: ExitCodes.Error, actual: result);
+    }
+
+    [Fact]
+    public async Task CleanupAsyncReturnsErrorWhenGlobMatchesNoFilesAsync()
+    {
+        string glob = Path.Combine(path1: this.TempFolder, path2: "*.doesnotexist");
+
+        int result = await this._commands.CleanupAsync(inputs: [glob]);
+
+        Assert.Equal(expected: ExitCodes.Error, actual: result);
+    }
+
+    [Fact]
+    public async Task CleanupAsyncReturnsErrorForUnsupportedFileTypeAsync()
+    {
+        string file = await this.CreateFileAsync(relativePath: "readme.txt", content: "hello");
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Error, actual: result);
+        await this
+            ._sourceFileReformatter.DidNotReceive()
+            .ReformatAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncProcessesExplicitCSharpFileAsync()
+    {
+        string file = await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.Equal(expected: "public class Foo { }", actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncWritesUpdatedCSharpFileContentAsync()
+    {
+        string file = await this.CreateFileAsync(
+            relativePath: "Foo.cs",
+            content: "// resharper disable\npublic class Foo { }"
+        );
+        this._resharperSuppressionToSuppressMessage.Replace(Arg.Any<string>()).Returns("public class Foo { }");
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.Equal(expected: "public class Foo { }", actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncDeduplicatesRepeatedInputsAsync()
+    {
+        string file = await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+
+        int result = await this._commands.CleanupAsync(inputs: [file, file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this
+            ._sourceFileReformatter.Received(1)
+            .ReformatAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncProcessesDirectoryInputRecursivelyExcludingGeneratedFilesAsync()
+    {
+        await this.CreateFileAsync(relativePath: Path.Combine("src", "Foo.cs"), content: "public class Foo { }");
+        await this.CreateFileAsync(
+            relativePath: Path.Combine("obj", "Debug", "Foo.cs"),
+            content: "public class Foo2 { }"
+        );
+        await this.CreateFileAsync(relativePath: Path.Combine("generated", "Bar.cs"), content: "public class Bar { }");
+        await this.CreateFileAsync(relativePath: "Baz.generated.cs", content: "public class Baz { }");
+        await this.CreateFileAsync(relativePath: "readme.txt", content: "hello");
+
+        int result = await this._commands.CleanupAsync(inputs: [this.TempFolder]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this
+            ._sourceFileReformatter.Received(1)
+            .ReformatAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncProcessesGlobInputAsync()
+    {
+        await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+        await this.CreateFileAsync(relativePath: "readme.txt", content: "hello");
+        string glob = Path.Combine(path1: this.TempFolder, path2: "*.cs");
+
+        int result = await this._commands.CleanupAsync(inputs: [glob]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this
+            ._sourceFileReformatter.Received(1)
+            .ReformatAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncProcessesUnchangedProjectFileAsync()
+    {
+        const string projectXml = "<Project Sdk=\"Microsoft.NET.Sdk\"></Project>";
+        string file = await this.CreateFileAsync(relativePath: "Test.csproj", content: projectXml);
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.Equal(expected: projectXml, actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncRewritesProjectFileWhenPropertyGroupsReorderedAsync()
+    {
+        const string projectXml =
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup></Project>";
+        string file = await this.CreateFileAsync(relativePath: "Test.csproj", content: projectXml);
+        this._projectXmlRewriter.ReOrderPropertyGroups(Arg.Any<XmlDocument>(), Arg.Any<string>()).Returns(true);
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.NotEqual(expected: projectXml, actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncRewritesProjectFileWhenIncludesReorderedAsync()
+    {
+        const string projectXml =
+            "<Project Sdk=\"Microsoft.NET.Sdk\"><ItemGroup><Compile Include=\"b.cs\" /><Compile Include=\"a.cs\" /></ItemGroup></Project>";
+        string file = await this.CreateFileAsync(relativePath: "Test.csproj", content: projectXml);
+        this._projectXmlRewriter.ReOrderIncludes(Arg.Any<XmlDocument>(), Arg.Any<string>()).Returns(true);
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.NotEqual(expected: projectXml, actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncDoesNotRewriteProjectFileWhenAlreadyCanonicalAsync()
+    {
+        const string rawXml = "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup></PropertyGroup></Project>";
+        XmlDocument document = new();
+        document.LoadXml(rawXml);
+        string canonicalXml = await ProjectXmlSerializer.ToProjectFileTextAsync(
+            document: document,
+            cancellationToken: this.CancellationToken()
+        );
+        string file = await this.CreateFileAsync(relativePath: "Test.csproj", content: canonicalXml);
+        this._projectXmlRewriter.ReOrderPropertyGroups(Arg.Any<XmlDocument>(), Arg.Any<string>()).Returns(true);
+
+        int result = await this._commands.CleanupAsync(inputs: [file]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        Assert.Equal(expected: canonicalXml, actual: await this.ReadFileAsync(file));
+    }
+
+    [Fact]
+    public async Task CleanupAsyncRemovesSuppressionsWhenBuildRootConfiguredAsync()
+    {
+        string buildRoot = this.TempFolder;
+        string project = await this.CreateFileAsync(
+            relativePath: "Test.csproj",
+            content: "<Project Sdk=\"Microsoft.NET.Sdk\" />"
+        );
+        string csFile = await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+        this.SetupBuildRoot(buildRoot: buildRoot, projects: [project]);
+
+        int result = await this._commands.CleanupAsync(
+            inputs: [csFile],
+            removeSuppressions: true,
+            buildRoot: buildRoot
+        );
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this.ReceivedRemoveSuppressionsAsync(1);
+        await this
+            ._dotNetFilesDetector.Received(1)
+            .FindAsync(baseFolder: buildRoot, cancellationToken: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CleanupAsyncDoesNotRemoveSuppressionsWithoutBuildRootAsync()
+    {
+        string csFile = await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+
+        int result = await this._commands.CleanupAsync(inputs: [csFile]);
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this.ReceivedRemoveSuppressionsAsync(0);
+    }
+
+    [Fact]
+    public async Task CleanupAsyncProcessesProjectFileWithoutUsingBuildContextForSuppressionsAsync()
+    {
+        string buildRoot = this.TempFolder;
+        string project = await this.CreateFileAsync(
+            relativePath: "Test.csproj",
+            content: "<Project Sdk=\"Microsoft.NET.Sdk\" />"
+        );
+        this.SetupBuildRoot(buildRoot: buildRoot, projects: [project]);
+        this._projectXmlRewriter.ReOrderPropertyGroups(Arg.Any<XmlDocument>(), Arg.Any<string>()).Returns(true);
+
+        int result = await this._commands.CleanupAsync(
+            inputs: [project],
+            removeSuppressions: true,
+            buildRoot: buildRoot
+        );
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this.ReceivedRemoveSuppressionsAsync(0);
+    }
+
+    [Fact]
+    public async Task CleanupAsyncAllowsBuildRootWhenRemoveSuppressionsDisabledAsync()
+    {
+        string buildRoot = this.TempFolder;
+        string csFile = await this.CreateFileAsync(relativePath: "Foo.cs", content: "public class Foo { }");
+
+        int result = await this._commands.CleanupAsync(
+            inputs: [csFile],
+            removeSuppressions: false,
+            buildRoot: buildRoot
+        );
+
+        Assert.Equal(expected: ExitCodes.Success, actual: result);
+        await this._dotNetFilesDetector.DidNotReceive().FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Credfeto.DotNet.Repo.Formatter.Tests/Credfeto.DotNet.Repo.Formatter.Tests.csproj
+++ b/src/Credfeto.DotNet.Repo.Formatter.Tests/Credfeto.DotNet.Repo.Formatter.Tests.csproj
@@ -60,8 +60,10 @@
   </ItemGroup>
   <Import Project="$(SolutionDir)UnitTests.props" Condition="Exists('$(SolutionDir)UnitTests.props')"/>
   <ItemGroup>
+    <ProjectReference Include="..\Credfeto.DotNet.Repo.Formatter\Credfeto.DotNet.Repo.Formatter.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Build\Credfeto.DotNet.Repo.Tools.Build.csproj" />
     <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.CleanUp\Credfeto.DotNet.Repo.Tools.CleanUp.csproj" />
+    <ProjectReference Include="..\Credfeto.DotNet.Repo.Tools.Extensions\Credfeto.DotNet.Repo.Tools.Extensions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FunFair.Test.Common" Version="6.2.4.1830"/>

--- a/src/Credfeto.DotNet.Repo.Formatter.Tests/DependencyInjectionTests.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter.Tests/DependencyInjectionTests.cs
@@ -1,7 +1,6 @@
-using Credfeto.DotNet.Repo.Tools.Build;
+using Credfeto.DotNet.Repo.Formatter.Setup;
 using Credfeto.DotNet.Repo.Tools.Build.Interfaces;
 using Credfeto.DotNet.Repo.Tools.CleanUp;
-using Credfeto.DotNet.Repo.Tools.CleanUp.Interfaces;
 using FunFair.Test.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -57,6 +56,6 @@ public sealed class DependencyInjectionTests : DependencyInjectionTestsBase
 
     private static IServiceCollection Configure(IServiceCollection services)
     {
-        return services.AddBuild().AddCleanUp();
+        return services.AddServices();
     }
 }

--- a/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Commands.cs
@@ -18,12 +18,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Credfeto.DotNet.Repo.Formatter;
 
-[SuppressMessage(
-    category: "Microsoft.Performance",
-    checkId: "CA1812:AvoidUninstantiatedInternalClasses",
-    Justification = "Instantiated by Cocona"
-)]
-internal sealed class Commands
+public sealed class Commands
 {
     private static readonly FrozenSet<string> SupportedExtensions = FrozenSet.Create(
         StringComparer.OrdinalIgnoreCase,
@@ -70,6 +65,11 @@ internal sealed class Commands
     }
 
     [Command(Description = "Format C# source files and project files")]
+    [SuppressMessage(
+        category: "Meziantou.Analyzer",
+        checkId: "MA0109: Consider adding an overload with a Span<T> or Memory<T>",
+        Justification = "string[] is required for Cocona to bind CLI positional arguments"
+    )]
     public async Task<int> CleanupAsync(
         [Argument(Description = "Files, globs, or folders to process")] string[] inputs,
         [Option(

--- a/src/Credfeto.DotNet.Repo.Formatter/Constants/ExitCodes.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Constants/ExitCodes.cs
@@ -1,6 +1,6 @@
 namespace Credfeto.DotNet.Repo.Formatter.Constants;
 
-internal static class ExitCodes
+public static class ExitCodes
 {
     public const int Success = 0;
     public const int Error = 1;

--- a/src/Credfeto.DotNet.Repo.Formatter/Setup/ApplicationSetup.cs
+++ b/src/Credfeto.DotNet.Repo.Formatter/Setup/ApplicationSetup.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Credfeto.DotNet.Repo.Formatter.Setup;
 
-internal static class ApplicationSetup
+public static class ApplicationSetup
 {
     public static IServiceCollection AddServices(this IServiceCollection services)
     {


### PR DESCRIPTION
## Summary

- Bootstraps the tracking PR for #141: add unit tests to achieve 100% code coverage for the Credfeto.DotNet.Repo.Formatter assembly (the cscleanup standalone tool).
- This draft currently contains only a placeholder CHANGELOG.md entry; the test implementation (covering Commands - file/glob/folder input resolution, error cases, and the .cs/.csproj processing pipeline) follows in subsequent commits.

Closes #141

## Test plan

- [ ] Commands tests cover file/glob/folder input resolution
- [ ] Commands tests cover error cases (invalid file type, missing --build-root with --remove-suppressions, non-existent build root)
- [ ] Commands tests cover the .cs and .csproj processing pipeline
- [ ] dotnet build / dotnet test pass
- [ ] dotnet buildcheck passes
- [ ] Full pre-commit gate passes